### PR TITLE
fix(group): 속하지 않은 그룹코드를 가진 url에 접속을해도 들어가지는 문제 해결

### DIFF
--- a/frontend/src/components/MembersProfile/MembersProfile.tsx
+++ b/frontend/src/components/MembersProfile/MembersProfile.tsx
@@ -26,6 +26,12 @@ function MembersProfile({ groupCode }: Props) {
           const statusCode = err.message;
 
           if (statusCode === '401') {
+            alert('로그인 해주세요~');
+            navigate('/');
+          }
+
+          if (statusCode === '404' || '403' || '400') {
+            alert('그룹이 없어요~');
             navigate('/');
           }
         }


### PR DESCRIPTION
## 상세 내용

- 속하지 않은 그룹코드를 가진 url에 접속을해도 들어가지는 문제 해결
- 403, 404, 400일시 landing page로 리다이렉트

Close #156
