### PR TITLE
feat: 달력 컴포넌트를 구현

### DIFF
--- a/frontend/src/components/common/Calendar/Calendar.stories.tsx
+++ b/frontend/src/components/common/Calendar/Calendar.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import Calendar from './Calendar';
+
+export default {
+  title: 'Reusable Components/Calendar',
+  component: Calendar
+} as Meta;
+
+const Template: Story = () => <Calendar />;
+
+export const Default = Template.bind({});

--- a/frontend/src/components/common/Calendar/Calendar.tsx
+++ b/frontend/src/components/common/Calendar/Calendar.tsx
@@ -66,12 +66,28 @@ function Calendar() {
       return;
     }
     setStartDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`); // 가장 처음 값을 설정해줌 
-  }
+  };
+
+  const isPrevToday = (day) => {
+    return new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(`${new Date().getFullYear()}-${new Date().getMonth() + 1}-${new Date().getDate()}`);
+  };
   
+  const isToday = (day) => {
+    return date.getFullYear() === new Date().getFullYear() && date.getMonth() === new Date().getMonth() && day === new Date().getDate();
+  };
+
+  const isBetweenStartEndDate = (day) => {
+    return new Date(startDate) < new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) && new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(endDate);
+  }
+
+  const isStartOrEndDate = (day) => {
+    return startDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}` || endDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}`;
+  }
+
   return (
     <StyledCalendar>
       <StyledMonth>
-        <StyledPrevButton onClick={handleShowPrevMonth} disabled={new Date().getMonth() === date.getMonth()}>&#8249;</StyledPrevButton>
+        <StyledPrevButton onClick={handleShowPrevMonth} disabled={new Date().getMonth() === date.getMonth()}>&#8249;</StyledPrevButton> 
         <StyledMonthTitle>{`${date.getFullYear()}년 ${date.getMonth() + 1}월`}</StyledMonthTitle>
         <StyledNextButton onClick={handleShowNextMonth}>&#8250;</StyledNextButton>
       </StyledMonth>
@@ -79,20 +95,22 @@ function Calendar() {
         {weeks.map((day) => <StyledWeekDay>{day}</StyledWeekDay>)}
       </StyledWeekends>
       <StyledDays>
+        {/* 지난 달 일부 날짜 */}
         {getPrevMonthDays().map((day) => (<StyledPrevMonthDays>{day}</StyledPrevMonthDays>))}
 
+        {/* 이번 달 날짜  */}
         {getNowMonthDays().map((day) => {
-          if (new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(`${new Date().getFullYear()}-${new Date().getMonth() + 1}-${new Date().getDate()}`)) {
+          if (isPrevToday(day)) {
             return (
             <StyledNowMonthDays type="prev">{day}</StyledNowMonthDays>)
           }
-          if (date.getFullYear() === new Date().getFullYear() && date.getMonth() === new Date().getMonth() && day === new Date().getDate()) {
+          if (isToday(day)) {
             return (
             <StyledNowMonthDays 
               type="today"
               onClick={handleSetStartOrEndDate(day)} 
-              isBetweenSelectedDate={new Date(startDate) < new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) && new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(endDate)} 
-              isSelectedDate={startDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}` || endDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}`} 
+              isBetweenStartEndDate={isBetweenStartEndDate(day)} 
+              isStartOrEndDate={isStartOrEndDate(day)} 
             >
               {day}
             </StyledNowMonthDays>)
@@ -100,13 +118,14 @@ function Calendar() {
           return (
           <StyledNowMonthDays 
             onClick={handleSetStartOrEndDate(day)} 
-            isBetweenSelectedDate={new Date(startDate) < new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) && new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(endDate)} 
-            isSelectedDate={startDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}` || endDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}`} 
+            isBetweenStartEndDate={isBetweenStartEndDate(day)} 
+            isStartOrEndDate={isStartOrEndDate(day)} 
           >
             {day}
           </StyledNowMonthDays>)
         })}
 
+        {/* 다음 달 일부 날짜  */}
         {getNextMonthDays().map((day) => (<StyledNextMonthDays>{day}</StyledNextMonthDays>))}
       </StyledDays>
     </StyledCalendar>
@@ -201,14 +220,14 @@ const StyledNextMonthDays = styled.div(({ theme }) => `
 `);
 
 const StyledNowMonthDays = styled.div<{
-  isBetweenSelectedDate?: boolean;
-  isSelectedDate?: boolean;
+  isBetweenStartEndDate?: boolean;
+  isStartOrEndDate?: boolean;
   type?: string;
-}>(({ theme, isBetweenSelectedDate, isSelectedDate, type }) => `
+}>(({ theme, isBetweenStartEndDate, isStartOrEndDate, type }) => `
   color: ${theme.colors.BLACK_100};
   
   // 선택 된 startDate, endDate라면 
-  ${ isSelectedDate? 
+  ${ isStartOrEndDate? 
     `background-color: ${theme.colors.PURPLE_100};
     color: ${theme.colors.WHITE_100};
     border-radius: 100%;` : ''
@@ -216,7 +235,7 @@ const StyledNowMonthDays = styled.div<{
 
   // 선택 된 startDate, endDate 사이에 있으면 
   // color theme으로 빼기 
-  ${ isBetweenSelectedDate?
+  ${ isBetweenStartEndDate?
     `background-color: #EEEDFF;
     border-radius: 100%;
     ` : ''
@@ -227,7 +246,7 @@ const StyledNowMonthDays = styled.div<{
   }
 
   ${type === 'today'?
-  `color: ${theme.colors.PURPLE_100};` : ''
+  `color: ${theme.colors.YELLOW_100};` : ''
 }
 `);
 

--- a/frontend/src/components/common/Calendar/Calendar.tsx
+++ b/frontend/src/components/common/Calendar/Calendar.tsx
@@ -6,7 +6,6 @@ function Calendar() {
   const [startDate, setStartDate] = useState(''); // 2022-08-20 과 같은 형식이 들어옴 -> new Date()로 감싸서 사용 가능
   const [endDate, setEndDate] = useState('');
   const weeks = ['일', '월', '화', '수', '목', '금', '토'];
-  console.log(startDate, endDate);
 
   const getPrevMonthDays = () => {
     const prevLastDay = new Date(date.getFullYear(), date.getMonth(), 0).getDate(); // 지난달 말일
@@ -42,7 +41,7 @@ function Calendar() {
     // 마지막 날이 선택 되어 있는 경우 -> 새로운 start 값을 설정해줘야함 
     if (endDate !== '') {
       setEndDate('');
-      setStartDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`);
+      setStartDate(`${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`);
       return;
     }
     // 첫번째 날이 선택 되어 있는 경우 -> end값을 설정해줘야함 
@@ -50,15 +49,15 @@ function Calendar() {
       // end값을 설정해줘야하는데, start 날짜보다 앞일 때
       if (isBeforeStartDate(day)) {
         setEndDate(startDate);
-        setStartDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`);
+        setStartDate(`${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`);
 
         return;
       }
-      setEndDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`);
+      setEndDate(`${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`);
       return;
     }
-    // 가장 처음 값을 설정해줌 (위 두가지가 아닌 경우)
-    setStartDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`); 
+    // 가장 처음 값을 설정해줌 (위 두가지 조건을 충족하지 않은 경우)
+    setStartDate(`${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`); 
   };
 
   const isPrevToday = (day) => {
@@ -70,11 +69,11 @@ function Calendar() {
   };
 
   const isBetweenStartEndDate = (day) => {
-    return new Date(startDate) < new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) && new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(endDate);
+    return new Date(startDate) < new Date(`${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`) && new Date(`${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`) < new Date(endDate);
   }
 
   const isStartOrEndDate = (day) => {
-    return startDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}` || endDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}`;
+    return startDate === `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}` || endDate === `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`;
   }
 
   const isBeforeStartDate = (day) => {

--- a/frontend/src/components/common/Calendar/Calendar.tsx
+++ b/frontend/src/components/common/Calendar/Calendar.tsx
@@ -6,6 +6,7 @@ function Calendar() {
   const [startDate, setStartDate] = useState(''); // 2022-08-20 과 같은 형식이 들어옴 -> new Date()로 감싸서 사용 가능
   const [endDate, setEndDate] = useState('');
   const weeks = ['일', '월', '화', '수', '목', '금', '토'];
+  console.log(startDate, endDate);
 
   const getPrevMonthDays = () => {
     const prevLastDay = new Date(date.getFullYear(), date.getMonth(), 0).getDate(); // 지난달 말일
@@ -46,6 +47,13 @@ function Calendar() {
     }
     // 첫번째 날이 선택 되어 있는 경우 -> end값을 설정해줘야함 
     if (startDate !== '' && endDate === '') {
+      // end값을 설정해줘야하는데, start 날짜보다 앞일 때
+      if (isBeforeStartDate(day)) {
+        setEndDate(startDate);
+        setStartDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`);
+
+        return;
+      }
       setEndDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`);
       return;
     }
@@ -67,6 +75,10 @@ function Calendar() {
 
   const isStartOrEndDate = (day) => {
     return startDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}` || endDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}`;
+  }
+
+  const isBeforeStartDate = (day) => {
+    return new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(startDate);
   }
 
   return (
@@ -215,7 +227,15 @@ const StyledNowMonthDays = styled.div<{
     border: 2px solid ${theme.colors.PURPLE_100};
     border-radius: 100%;
   }
-  
+
+  ${type === 'prev'?
+    `color: ${theme.colors.GRAY_200};` : ''
+  }
+
+  ${type === 'today'?
+  `color: ${theme.colors.BLACK_100};` : '' // 현재는 일반 날짜와 다른 것이 없지만, 이후 today에 대한 스타일이 필요하면 속성 추가 가능
+  }
+
   ${ isStartOrEndDate? 
     `background-color: ${theme.colors.PURPLE_100};
     color: ${theme.colors.WHITE_100};
@@ -226,14 +246,6 @@ const StyledNowMonthDays = styled.div<{
     `background-color: ${theme.colors.PURPLE_50};
     border-radius: 100%;
     ` : ''
-  }
-
-  ${type === 'prev'?
-    `color: ${theme.colors.GRAY_200};` : ''
-  }
-
-  ${type === 'today'?
-  `color: ${theme.colors.YELLOW_100};` : ''
   }
 `);
 

--- a/frontend/src/components/common/Calendar/Calendar.tsx
+++ b/frontend/src/components/common/Calendar/Calendar.tsx
@@ -1,0 +1,226 @@
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+
+// 이전, 다음 버튼 구현
+// 버전 -> today를 보여주는가?(지금 잠시 주석처리) , 이전 날짜를 이동할 수 없게 할 것인가? (글자disabled, 버튼 disabled)
+function Calendar() {
+  const [date, setDate] = useState<Date>(new Date()); 
+  const [startDate, setStartDate] = useState(''); // new Date로 감싸서 사용하면 됨 
+  const [endDate, setEndDate] = useState('');
+  const weeks = ['일', '월', '화', '수', '목', '금', '토'];
+
+  const getPrevMonthDays = () => {
+    const days = [];
+    const prevLastDay = new Date(date.getFullYear(), date.getMonth(), 0).getDate(); // 6월 말일
+    date.setDate(1);
+    const firstDayIndex = date.getDay(); // 1일의 요일
+
+    for (let x = firstDayIndex; x > 0; x--) {
+      days.push(prevLastDay - x + 1);
+    }
+
+    return days;
+  };
+
+  const getNowMonthDays = () => {
+    const days = [];
+    const lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate(); // 7월 말일
+
+    for (let i = 1; i <= lastDay; i++) {
+        days.push(i);
+    }
+
+    return days;
+  };
+
+  const getNextMonthDays = () => {
+    const days = [];
+    const lastDayIndex = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDay(); // 막날의 요일
+    const nextDays = 7 - lastDayIndex - 1; // 다음달 날짜
+
+    for (let j = 1; j <= nextDays; j++) {
+      days.push(j);
+    }
+
+    return days;
+  };
+
+  const handleShowPrevMonth = () => {
+    const nowDate = date;
+    setDate(new Date(nowDate.getFullYear(), nowDate.getMonth() - 1, 1))
+  };
+
+  const handleShowNextMonth = () => {
+    const nowDate = date;
+    setDate(new Date(nowDate.getFullYear(), nowDate.getMonth() + 1, 1))
+  };
+
+  const handleClickDay = (day: number) => () =>  {
+    // 마지막 날이 선택 되어 있는 경우 -> 새로운 start 값을 설정해줘야함 
+    if(endDate !== '') {
+      setEndDate('');
+      setStartDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`);
+      return;
+    }
+    // 첫번째 날이 선택 되어 있는 경우 -> end값을 설정해줘야함 
+    if(startDate !== '' && endDate === '') {
+      setEndDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`);
+      return;
+    }
+    setStartDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`); // 가장 처음 값을 설정해줌 
+  }
+  
+  return (
+    <StyledCalendar>
+      <StyledMonth>
+        <StyledPrevButton onClick={handleShowPrevMonth} disabled={new Date().getMonth() === date.getMonth()}>&#8249;</StyledPrevButton>
+        <StyledMonthTitle>{`${date.getFullYear()}년 ${date.getMonth() + 1}월`}</StyledMonthTitle>
+        <StyledNextButton onClick={handleShowNextMonth}>&#8250;</StyledNextButton>
+      </StyledMonth>
+      <StyledWeekends>
+        {weeks.map((day) => <StyledWeekDay>{day}</StyledWeekDay>)}
+      </StyledWeekends>
+      <StyledDays>
+        {getPrevMonthDays().map((day) => (<StyledPrevMonthDays>{day}</StyledPrevMonthDays>))}
+        {getNowMonthDays().map((day) => {
+          if (new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(`${new Date().getFullYear()}-${new Date().getMonth() + 1}-${new Date().getDate()}`)) {
+            return (<StyledPrevToday>{day}</StyledPrevToday>)
+          }
+          if (date.getFullYear() === new Date().getFullYear() && date.getMonth() === new Date().getMonth() && day === new Date().getDate()) {
+            return (<StyledTodayMonthDays>{day}</StyledTodayMonthDays>)
+          }
+          return (
+          <StyledNowMonthDays 
+            onClick={handleClickDay(day)} 
+            isBetweenSelectedDate={new Date(startDate) < new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) && new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(endDate)} 
+            isSelectedDate={startDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}` || endDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}`} 
+          >
+              {day}
+          </StyledNowMonthDays>)
+        })}
+        {getNextMonthDays().map((day) => (<StyledNextMonthDays>{day}</StyledNextMonthDays>))}
+      </StyledDays>
+    </StyledCalendar>
+  );
+}
+
+// css 점검 (4단위, height 없애기)
+const StyledCalendar = styled.div(({ theme }) => `
+  width: 45.2rem;
+  height: 60rem;
+  background: ${theme.colors.WHITE_100};
+  border-radius: 2rem;
+`);
+
+const StyledMonth = styled.div`
+  width: 100%;
+  height: 12rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 2rem;
+  text-align: center;
+`;
+
+const StyledWeekends = styled.div`
+  width: 100%;
+  height: 5.2rem;
+  padding: 0 0.4rem;
+  display: flex;
+  align-items: center;
+`;
+
+const StyledWeekDay = styled.div`
+  font-size: 1.6rem;
+  font-weight: 400;
+  letter-spacing: 0.12rem;
+  width: calc(44.2rem / 7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+// 중복 (rightButton)
+const StyledPrevButton = styled.button`
+  font-size: 4.4rem;
+  opacity: 0.5;
+`;
+
+const StyledNextButton = styled.button`
+  font-size: 4.4rem;
+  opacity: 0.5;
+`;
+
+const StyledMonthTitle = styled.h1`
+  font-size: 2.4rem;
+  font-weight: 400;
+  text-transform: uppercase;
+`;
+
+const StyledDays = styled.div(({ theme }) => `
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0.4rem;
+  cursor: pointer;
+
+  div {
+    font-size: 1.6rem;
+    // 0.4하면 깨짐 
+    margin: 0.3rem; 
+    width: calc(40.2rem / 7);
+    height: calc(40.2rem / 7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    transition: background-color 0.2s;
+  }
+
+  // 클릭되면 filled로 채워주기 
+  div:hover {
+    border: 2px solid ${theme.colors.PURPLE_100};
+    border-radius: 100%;
+  }
+`);
+
+const StyledPrevMonthDays = styled.div(({ theme }) => `
+  color: ${theme.colors.GRAY_200};
+`);
+
+const StyledNextMonthDays = styled.div(({ theme }) => `
+  color: ${theme.colors.GRAY_200};
+`);
+
+const StyledNowMonthDays = styled.div<{
+  isBetweenSelectedDate: boolean;
+  isSelectedDate: boolean;
+}>(({ theme, isBetweenSelectedDate, isSelectedDate }) => `
+  color: ${theme.colors.BLACK_100};
+  
+  // 선택 된 startDate, endDate라면 
+  ${ isSelectedDate? 
+    `background-color: ${theme.colors.PURPLE_100};
+    color: ${theme.colors.WHITE_100};
+    border-radius: 100%;` : ''
+  }
+
+  // 선택 된 startDate, endDate 사이에 있으면 
+  // color theme으로 빼기 
+  ${ isBetweenSelectedDate?
+    `background-color: #EEEDFF;
+    border-radius: 100%;
+    ` : ''
+  }
+`);
+
+const StyledTodayMonthDays = styled.div(({ theme }) => `
+  // background-color: ${theme.colors.PURPLE_100};
+  color: ${theme.colors.PURPLE_100};
+  border-radius: 100%;
+`);
+
+const StyledPrevToday = styled.div(({theme}) => `
+  color: ${theme.colors.GRAY_200};
+`);
+
+export default Calendar;

--- a/frontend/src/components/common/Calendar/Calendar.tsx
+++ b/frontend/src/components/common/Calendar/Calendar.tsx
@@ -8,39 +8,25 @@ function Calendar() {
   const weeks = ['일', '월', '화', '수', '목', '금', '토'];
 
   const getPrevMonthDays = () => {
-    const days = [];
-    const prevLastDay = new Date(date.getFullYear(), date.getMonth(), 0).getDate(); // 6월 말일
+    const prevLastDay = new Date(date.getFullYear(), date.getMonth(), 0).getDate(); // 지난달 말일
     date.setDate(1);
     const firstDayIndex = date.getDay(); // 1일의 요일
 
-    for (let x = firstDayIndex; x > 0; x--) {
-      days.push(prevLastDay - x + 1);
-    }
-
-    return days;
+    return Array.from({length: firstDayIndex}, (v, i) => prevLastDay - (firstDayIndex - i) + 1);
   };
 
   const getNowMonthDays = () => {
-    const days = [];
-    const lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate(); // 7월 말일
+    const lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate(); // 이번달 말일
 
-    for (let i = 1; i <= lastDay; i++) {
-        days.push(i);
-    }
+    return Array.from({length: lastDay}, (v, i) => i + 1);
 
-    return days;
   };
 
   const getNextMonthDays = () => {
-    const days = [];
     const lastDayIndex = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDay(); // 막날의 요일
     const nextDays = 7 - lastDayIndex - 1; // 다음달 날짜
 
-    for (let j = 1; j <= nextDays; j++) {
-      days.push(j);
-    }
-
-    return days;
+    return Array.from({length: nextDays}, (v, i) => i + 1);
   };
 
   const handleShowPrevMonth = () => {
@@ -168,7 +154,6 @@ const StyledWeekDay = styled.div`
   align-items: center;
 `;
 
-// 중복 (rightButton)
 const StyledPrevButton = styled.button`
   font-size: 4.4rem;
   opacity: 0.5;
@@ -185,7 +170,7 @@ const StyledMonthTitle = styled.h1`
   text-transform: uppercase;
 `;
 
-const StyledDays = styled.div(({ theme }) => `
+const StyledDays = styled.div`
   width: 100%;
   display: flex;
   flex-wrap: wrap;
@@ -203,16 +188,10 @@ const StyledDays = styled.div(({ theme }) => `
     align-items: center;
     transition: background-color 0.2s;
   }
-
-  // 클릭되면 filled로 채워주기 
-  div:hover {
-    border: 2px solid ${theme.colors.PURPLE_100};
-    border-radius: 100%;
-  }
-`);
+`;
 
 const StyledPrevMonthDays = styled.div(({ theme }) => `
-  color: ${theme.colors.GRAY_200};
+  color: ${theme.colors.GRAY_200}; 
 `);
 
 const StyledNextMonthDays = styled.div(({ theme }) => `
@@ -247,7 +226,12 @@ const StyledNowMonthDays = styled.div<{
 
   ${type === 'today'?
   `color: ${theme.colors.YELLOW_100};` : ''
-}
+  }
+
+  &:hover {
+    border: 2px solid ${theme.colors.PURPLE_100};
+    border-radius: 100%;
+  }
 `);
 
 

--- a/frontend/src/components/common/Calendar/Calendar.tsx
+++ b/frontend/src/components/common/Calendar/Calendar.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
 
-// 이전, 다음 버튼 구현
-// 버전 -> today를 보여주는가?(지금 잠시 주석처리) , 이전 날짜를 이동할 수 없게 할 것인가? (글자disabled, 버튼 disabled)
 function Calendar() {
   const [date, setDate] = useState<Date>(new Date()); 
-  const [startDate, setStartDate] = useState(''); // new Date로 감싸서 사용하면 됨 
+  const [startDate, setStartDate] = useState(''); // 2022-08-20 과 같은 형식이 들어옴 -> new Date()로 감싸서 사용 가능
   const [endDate, setEndDate] = useState('');
   const weeks = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -55,15 +53,15 @@ function Calendar() {
     setDate(new Date(nowDate.getFullYear(), nowDate.getMonth() + 1, 1))
   };
 
-  const handleClickDay = (day: number) => () =>  {
+  const handleSetStartOrEndDate = (day: number) => () =>  {
     // 마지막 날이 선택 되어 있는 경우 -> 새로운 start 값을 설정해줘야함 
-    if(endDate !== '') {
+    if (endDate !== '') {
       setEndDate('');
       setStartDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`);
       return;
     }
     // 첫번째 날이 선택 되어 있는 경우 -> end값을 설정해줘야함 
-    if(startDate !== '' && endDate === '') {
+    if (startDate !== '' && endDate === '') {
       setEndDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`);
       return;
     }
@@ -82,22 +80,33 @@ function Calendar() {
       </StyledWeekends>
       <StyledDays>
         {getPrevMonthDays().map((day) => (<StyledPrevMonthDays>{day}</StyledPrevMonthDays>))}
+
         {getNowMonthDays().map((day) => {
           if (new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(`${new Date().getFullYear()}-${new Date().getMonth() + 1}-${new Date().getDate()}`)) {
-            return (<StyledPrevToday>{day}</StyledPrevToday>)
+            return (
+            <StyledNowMonthDays type="prev">{day}</StyledNowMonthDays>)
           }
           if (date.getFullYear() === new Date().getFullYear() && date.getMonth() === new Date().getMonth() && day === new Date().getDate()) {
-            return (<StyledTodayMonthDays>{day}</StyledTodayMonthDays>)
+            return (
+            <StyledNowMonthDays 
+              type="today"
+              onClick={handleSetStartOrEndDate(day)} 
+              isBetweenSelectedDate={new Date(startDate) < new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) && new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(endDate)} 
+              isSelectedDate={startDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}` || endDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}`} 
+            >
+              {day}
+            </StyledNowMonthDays>)
           }
           return (
           <StyledNowMonthDays 
-            onClick={handleClickDay(day)} 
+            onClick={handleSetStartOrEndDate(day)} 
             isBetweenSelectedDate={new Date(startDate) < new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) && new Date(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`) < new Date(endDate)} 
             isSelectedDate={startDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}` || endDate === `${date.getFullYear()}-${date.getMonth() + 1}-${day}`} 
           >
-              {day}
+            {day}
           </StyledNowMonthDays>)
         })}
+
         {getNextMonthDays().map((day) => (<StyledNextMonthDays>{day}</StyledNextMonthDays>))}
       </StyledDays>
     </StyledCalendar>
@@ -192,9 +201,10 @@ const StyledNextMonthDays = styled.div(({ theme }) => `
 `);
 
 const StyledNowMonthDays = styled.div<{
-  isBetweenSelectedDate: boolean;
-  isSelectedDate: boolean;
-}>(({ theme, isBetweenSelectedDate, isSelectedDate }) => `
+  isBetweenSelectedDate?: boolean;
+  isSelectedDate?: boolean;
+  type?: string;
+}>(({ theme, isBetweenSelectedDate, isSelectedDate, type }) => `
   color: ${theme.colors.BLACK_100};
   
   // 선택 된 startDate, endDate라면 
@@ -211,16 +221,15 @@ const StyledNowMonthDays = styled.div<{
     border-radius: 100%;
     ` : ''
   }
+
+  ${type === 'prev'?
+    `color: ${theme.colors.GRAY_200};` : ''
+  }
+
+  ${type === 'today'?
+  `color: ${theme.colors.PURPLE_100};` : ''
+}
 `);
 
-const StyledTodayMonthDays = styled.div(({ theme }) => `
-  // background-color: ${theme.colors.PURPLE_100};
-  color: ${theme.colors.PURPLE_100};
-  border-radius: 100%;
-`);
-
-const StyledPrevToday = styled.div(({theme}) => `
-  color: ${theme.colors.GRAY_200};
-`);
 
 export default Calendar;

--- a/frontend/src/components/common/Calendar/Calendar.tsx
+++ b/frontend/src/components/common/Calendar/Calendar.tsx
@@ -30,13 +30,11 @@ function Calendar() {
   };
 
   const handleShowPrevMonth = () => {
-    const nowDate = date;
-    setDate(new Date(nowDate.getFullYear(), nowDate.getMonth() - 1, 1))
+    setDate(new Date(date.getFullYear(), date.getMonth() - 1, 1))
   };
 
   const handleShowNextMonth = () => {
-    const nowDate = date;
-    setDate(new Date(nowDate.getFullYear(), nowDate.getMonth() + 1, 1))
+    setDate(new Date(date.getFullYear(), date.getMonth() + 1, 1))
   };
 
   const handleSetStartOrEndDate = (day: number) => () =>  {
@@ -51,7 +49,8 @@ function Calendar() {
       setEndDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`);
       return;
     }
-    setStartDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`); // 가장 처음 값을 설정해줌 
+    // 가장 처음 값을 설정해줌 (위 두가지가 아닌 경우)
+    setStartDate(`${date.getFullYear()}-${date.getMonth() + 1}-${day}`); 
   };
 
   const isPrevToday = (day) => {
@@ -118,10 +117,9 @@ function Calendar() {
   );
 }
 
-// css 점검 (4단위, height 없애기)
 const StyledCalendar = styled.div(({ theme }) => `
   width: 45.2rem;
-  height: 60rem;
+  height: 54rem;
   background: ${theme.colors.WHITE_100};
   border-radius: 2rem;
 `);
@@ -146,12 +144,9 @@ const StyledWeekends = styled.div`
 
 const StyledWeekDay = styled.div`
   font-size: 1.6rem;
-  font-weight: 400;
-  letter-spacing: 0.12rem;
-  width: calc(44.2rem / 7);
+  width: calc(45.2rem / 7);
   display: flex;
   justify-content: center;
-  align-items: center;
 `;
 
 const StyledPrevButton = styled.button`
@@ -166,8 +161,6 @@ const StyledNextButton = styled.button`
 
 const StyledMonthTitle = styled.h1`
   font-size: 2.4rem;
-  font-weight: 400;
-  text-transform: uppercase;
 `;
 
 const StyledDays = styled.div`
@@ -176,26 +169,31 @@ const StyledDays = styled.div`
   flex-wrap: wrap;
   padding: 0.4rem;
   cursor: pointer;
-
-  div {
-    font-size: 1.6rem;
-    // 0.4하면 깨짐 
-    margin: 0.3rem; 
-    width: calc(40.2rem / 7);
-    height: calc(40.2rem / 7);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    transition: background-color 0.2s;
-  }
 `;
 
+// TODO: StyledPrevMonthDays, StyledNextMonthDays, StyledNowMonthDays에 공통적인 스타일이 들어감 (4단위로 맞지 않는 부분이 있는데, 4단위로 맞추면 깨지는 이슈...)
 const StyledPrevMonthDays = styled.div(({ theme }) => `
-  color: ${theme.colors.GRAY_200}; 
+  color: ${theme.colors.WHITE_100}; // TODO: 현재 달력에서는 이전달, 다음달 날짜 일부를 보여줄 필요가 없어서 화면에서 보이지 않도록 처리. (이후 필요할 시, props로 option을 받아서 보이도록 해줄 수 있음)
+  font-size: 1.6rem;
+  margin: 0.3rem; 
+  width: calc(40.2rem / 7);
+  height: calc(40.2rem / 7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: background-color 0.2s;
 `);
 
 const StyledNextMonthDays = styled.div(({ theme }) => `
-  color: ${theme.colors.GRAY_200};
+  color: ${theme.colors.WHITE_100};
+  font-size: 1.6rem;
+  margin: 0.3rem; 
+  width: calc(40.2rem / 7);
+  height: calc(40.2rem / 7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: background-color 0.2s;
 `);
 
 const StyledNowMonthDays = styled.div<{
@@ -204,18 +202,28 @@ const StyledNowMonthDays = styled.div<{
   type?: string;
 }>(({ theme, isBetweenStartEndDate, isStartOrEndDate, type }) => `
   color: ${theme.colors.BLACK_100};
+  font-size: 1.6rem;
+  margin: 0.3rem; 
+  width: calc(40.2rem / 7);
+  height: calc(40.2rem / 7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transition: background-color 0.3s;
+
+  &:hover {
+    border: 2px solid ${theme.colors.PURPLE_100};
+    border-radius: 100%;
+  }
   
-  // 선택 된 startDate, endDate라면 
   ${ isStartOrEndDate? 
     `background-color: ${theme.colors.PURPLE_100};
     color: ${theme.colors.WHITE_100};
     border-radius: 100%;` : ''
   }
 
-  // 선택 된 startDate, endDate 사이에 있으면 
-  // color theme으로 빼기 
   ${ isBetweenStartEndDate?
-    `background-color: #EEEDFF;
+    `background-color: ${theme.colors.PURPLE_50};
     border-radius: 100%;
     ` : ''
   }
@@ -226,11 +234,6 @@ const StyledNowMonthDays = styled.div<{
 
   ${type === 'today'?
   `color: ${theme.colors.YELLOW_100};` : ''
-  }
-
-  &:hover {
-    border: 2px solid ${theme.colors.PURPLE_100};
-    border-radius: 100%;
   }
 `);
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -3,6 +3,7 @@ const colors = {
   GRAY_200: '#E2E2E2',
   GRAY_300: '#D0D0D0',
   GRAY_400: '#979797',
+  PURPLE_50: '#EEEDFF',
   PURPLE_100: '#6F4DE3',
   YELLOW_100: '#F8C846',
   WHITE_100: '#FFFFFF',


### PR DESCRIPTION
## 상세 내용
- 상세 구현 내용은 이슈(#118)를 참고해주세요.  
- 상태를 분리하지 못했습니다. (hook으로 분리해보고자 시도했지만, 엉망이 되어서 다시 원상복구 했습니다... 더 찾아보고 개선해보겠습니다!) 
- 현재 props로 version을 받아서, version에 따라 다른 형태의 캘린더가 보이도록 구현했습니다. 
default 설정값인 `version="default"`는, 약속 잡기 생성하기에 대한 캘린더이며 
`version="select`"는 약속 잡기 선택하기에 대한 캘린더입니다. 
(version을 나눈 것 때문에 `<StyledDays>` 내부 분기 처리를 해서 코드가 조금 지저분해보이는데, 이 부분은 어떻게 더 깔끔하게 만들지 고민이 더 필요할 것 같습니다.) 
- ui만 담당하는 Calendar 컴포넌트를 common으로 넣고, 약속 잡기 생성하기, 약속 잡기 선택하기에 대한 Calendar 컴포넌트를 common Calendar로 부터 새로 생성하는 것이 나을 수도 있겠다는 생각이 듭니다. 함께 얘기해보면 좋을 것 같아요! 

## props "version" 추가 설명 
- `version="default"`
약속 잡기 생성하기에서 사용되는 캘린더 버전입니다. 
<img width="373" alt="스크린샷 2022-08-02 오후 2 18 40" src="https://user-images.githubusercontent.com/52344833/182297425-1a164c45-e5e2-4072-9650-90b689fc5b9d.png">


- `version="select"`
약속 잡기 선택하기에서 사용되는 캘린더 버전입니다. 
props로 받은 `startDate`, `endDate` 범위에 포함되지 않는 날짜는 클릭되지 않도록 disabled처리 해주었습니다. 
아래 사진에서는, `startDate`가 '2022-08-04', `endDate`가 '2022-08-20'임을 가정합니다. 
<img width="379" alt="스크린샷 2022-08-02 오후 2 18 07" src="https://user-images.githubusercontent.com/52344833/182297363-01636aa3-ed72-4ae6-b331-917384842896.png">

---
생각보다 어려웠네요... 🤯 궁금한 점, 논의할 부분이 있다면 언제든지 불러주세요! 
Close #118 
