### PR TITLE
fix: 요청 body를 두번 읽을 경우 발생하는 에러 수정

### DIFF
--- a/backend/src/main/java/com/morak/back/core/domain/CachedBodyHttpServletRequest.java
+++ b/backend/src/main/java/com/morak/back/core/domain/CachedBodyHttpServletRequest.java
@@ -1,0 +1,68 @@
+package com.morak.back.core.domain;
+
+import com.morak.back.core.exception.CachedBodyException;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import org.springframework.util.StreamUtils;
+
+public class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+
+    private final byte[] cachedBody;
+
+    public CachedBodyHttpServletRequest(HttpServletRequest request) throws IOException {
+        super(request);
+        InputStream requestInputStream = request.getInputStream();
+        this.cachedBody = StreamUtils.copyToByteArray(requestInputStream);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        return new CachedBodyServletInputStream(this.cachedBody);
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(this.cachedBody);
+        return new BufferedReader(new InputStreamReader(byteArrayInputStream));
+    }
+
+    private static class CachedBodyServletInputStream extends ServletInputStream {
+
+        private final InputStream cachedBodyInputStream;
+
+        public CachedBodyServletInputStream(byte[] cachedBody) {
+            this.cachedBodyInputStream = new ByteArrayInputStream(cachedBody);
+        }
+
+        @Override
+        public int read() throws IOException {
+            return cachedBodyInputStream.read();
+        }
+
+        @Override
+        public boolean isFinished() {
+            try {
+                return cachedBodyInputStream.available() == 0;
+            } catch (IOException e) {
+                throw new CachedBodyException("CachedBodyServletInputStream에 읽을 데이터가 남아있는지 확인하는데 실패했습니다.");
+            }
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new CachedBodyException("CachedBodyServletInputStream에서는 지원하지 않는 메서드입니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/morak/back/core/exception/CachedBodyException.java
+++ b/backend/src/main/java/com/morak/back/core/exception/CachedBodyException.java
@@ -1,0 +1,8 @@
+package com.morak.back.core.exception;
+
+public class CachedBodyException extends MorakException {
+
+    public CachedBodyException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/morak/back/core/ui/CacheBodyFilter.java
+++ b/backend/src/main/java/com/morak/back/core/ui/CacheBodyFilter.java
@@ -1,0 +1,26 @@
+package com.morak.back.core.ui;
+
+import com.morak.back.core.domain.CachedBodyHttpServletRequest;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CacheBodyFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        CachedBodyHttpServletRequest cachedBodyHttpServletRequest =
+                new CachedBodyHttpServletRequest(httpServletRequest);
+
+        filterChain.doFilter(cachedBodyHttpServletRequest, httpServletResponse);
+    }
+}

--- a/backend/src/main/java/com/morak/back/core/ui/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/morak/back/core/ui/GlobalControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.morak.back.core.ui;
 
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.morak.back.core.exception.CachedBodyException;
 import com.morak.back.core.exception.InvalidRequestException;
 import com.morak.back.core.exception.MorakException;
 import com.morak.back.core.exception.ResourceNotFoundException;
@@ -26,7 +27,8 @@ public class GlobalControllerAdvice {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
-    @ExceptionHandler({MismatchedInputException.class, InvalidRequestException.class, HttpMessageNotReadableException.class})
+    @ExceptionHandler({MismatchedInputException.class, InvalidRequestException.class,
+            HttpMessageNotReadableException.class})
     public ResponseEntity<ExceptionResponse> handleMismatchedInput(MorakException e) {
         logger.warn(e.getMessage());
 
@@ -45,12 +47,17 @@ public class GlobalControllerAdvice {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionResponse("잘못된 값이 입력되었습니다."));
     }
 
+    @ExceptionHandler(CachedBodyException.class)
+    public ResponseEntity<ExceptionResponse> handleCachedBodyException(CachedBodyException e) {
+        logger.warn(e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionResponse("요청 정보를 캐싱하는데 실패했습니다."));
+    }
+
     @ExceptionHandler(MorakException.class)
     public ResponseEntity<ExceptionResponse> handleMorakException(MorakException e) {
         logger.warn(e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionResponse("처리하지 못한 예외입니다."));
     }
-
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ExceptionResponse> handleUndefined(RuntimeException e, HttpServletRequest request)


### PR DESCRIPTION
## 상세 내용
몰랐는데 **요청 body는 요청 라이프사이클 과정에서 딱 한번만 읽을 수 있도록 설계**되어 있었습니다. 
`@RequestBody`로 요청 body를 불러올 때 내부적으로 `RequestResponseBodyMethodProcessor`가 이를 처리하는데, 그 과정에서 `HttpServletRequest#getInputStream`을 사용해버립니다. 따라서 이후에 에러가 발생해 로그 메시지를 만드는 과정에서 `LogFormatter`에서도 또 `HttpServletRequest#getInputStream`을 사용해 문제가 생겼었습니다. 

따라서 `HttpServletRequest`를 상속한 클래스를 만들어 **요청 body를 캐싱**해 사용하도록 변경해 문제를 해결했습니다. 
참고 : https://www.baeldung.com/spring-reading-httpservletrequest-multiple-times

### 찜찜쓰
- 현재 500 에러 상황에서만 캐싱이 필요하지만 모든 요청을 캐싱하고 있어 성능 이슈가 있을 수 있습니다. 
- 테스트를 만들고 싶었지만 직접 `HttpServletRequest`를 만들기 어려워 못했습니다. 아이디어를 주세요(구걸)

더 공부해서 개선하겠습니다🦥

Close #183 
