### PR TITLE
chore: RestDocs 문서 경로 변경 및 dev에서만 접근할 수 있게 설정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -76,7 +76,7 @@ task createDocument(type: Copy) {
     dependsOn asciidoctor
 
     from file("build/docs/asciidoc")
-    into file("src/main/resources/static")
+    into file("src/main/resources/static/docs")
 }
 
 bootJar {


### PR DESCRIPTION
## 상세 내용

RestDocs로 생성되는 문서의 경로를 `/static/docs`로 변경했습니다. 
추가적으로, dev Nginx에서 `/docs`에 대한 `location` 설정을 추가해 develop 환경에서만 API 문서에 접근할 수 있도록 했습니다. 

더 좋은 방법이 있다면 알려주세용🐨

Close #209 
