### PR TITLE
feat: 존재하지 않는 API 요청 시 커스텀 예외 응답

### DIFF
--- a/backend/src/main/java/com/morak/back/core/config/WebConfig.java
+++ b/backend/src/main/java/com/morak/back/core/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.morak.back.core.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -15,5 +16,11 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedMethods(ALLOWED_METHOD_NAMES.split(","))
                 .exposedHeaders(HttpHeaders.LOCATION);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/docs/**")
+                .addResourceLocations("classpath:/static/docs/");
     }
 }

--- a/backend/src/main/java/com/morak/back/core/exception/CustomErrorCode.java
+++ b/backend/src/main/java/com/morak/back/core/exception/CustomErrorCode.java
@@ -53,11 +53,10 @@ public enum CustomErrorCode {
     APPOINTMENT_NOT_FOUND_ERROR("3300", "요청한 약속잡기를 찾을 수 없습니다."),
 
     INVALID_PROPERTY_ERROR("4000", "잘못된 값이 입력되었습니다."),
-    CACHED_BODY_ERROR("4100", "캐시바디"),
+    API_NOT_FOUND_ERROR("4300", "요청한 API가 존재하지 않습니다"),
 
     MORAK_ERROR("9901", "처리하지 못한 예외입니다."),
     RUNTIME_ERROR("9902", "예상치 못한 예외입니다.");
-
     private final String number;
     private final String information;
 }

--- a/backend/src/main/java/com/morak/back/core/exception/CustomErrorCode.java
+++ b/backend/src/main/java/com/morak/back/core/exception/CustomErrorCode.java
@@ -57,6 +57,7 @@ public enum CustomErrorCode {
 
     MORAK_ERROR("9901", "처리하지 못한 예외입니다."),
     RUNTIME_ERROR("9902", "예상치 못한 예외입니다.");
+    
     private final String number;
     private final String information;
 }

--- a/backend/src/main/java/com/morak/back/core/ui/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/morak/back/core/ui/GlobalControllerAdvice.java
@@ -24,6 +24,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
 @RestControllerAdvice
@@ -104,6 +105,15 @@ public class GlobalControllerAdvice {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ExceptionResponse(CustomErrorCode.MORAK_ERROR.getNumber(), "처리하지 못한 예외입니다."));
     }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ExceptionResponse> noHandlerFoundHandle(NoHandlerFoundException e) {
+        logger.warn(e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ExceptionResponse(CustomErrorCode.API_NOT_FOUND_ERROR.getNumber(), "처리할 수 없는 요청입니다."));
+    }
+
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ExceptionResponse> handleUndefined(RuntimeException e,

--- a/backend/src/main/java/com/morak/back/core/ui/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/morak/back/core/ui/GlobalControllerAdvice.java
@@ -113,8 +113,7 @@ public class GlobalControllerAdvice {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(new ExceptionResponse(CustomErrorCode.API_NOT_FOUND_ERROR.getNumber(), "처리할 수 없는 요청입니다."));
     }
-
-
+    
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ExceptionResponse> handleUndefined(RuntimeException e,
                                                              ContentCachingRequestWrapper requestWrapper) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
       mode: always
   mvc:
     log-resolved-exception: off
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
 
 ---
 

--- a/backend/src/test/java/com/morak/back/core/ui/ApiNotFoundTest.java
+++ b/backend/src/test/java/com/morak/back/core/ui/ApiNotFoundTest.java
@@ -1,0 +1,31 @@
+package com.morak.back.core.ui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.morak.back.AcceptanceTest;
+import com.morak.back.SimpleRestAssured;
+import com.morak.back.core.exception.CustomErrorCode;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+public class ApiNotFoundTest extends AcceptanceTest {
+
+    @Test
+    void 존재하지_않는_API가_요청되면_NOT_FOUND를_응답한다() {
+        // given
+        String invalidApi = "invalidApi";
+
+        // when
+        ExtractableResponse<Response> response = SimpleRestAssured.get(invalidApi);
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value()),
+                () -> assertThat(SimpleRestAssured.extractCodeNumber(response))
+                        .isEqualTo(CustomErrorCode.API_NOT_FOUND_ERROR.getNumber())
+        );
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -4,7 +4,11 @@ spring:
   sql:
     init:
       mode: always
-
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
 ---
 
 spring:


### PR DESCRIPTION
## 상세 내용
프론트 측에서 존재하지 않는 API에 요청을 보내면 404가 반환되는데,
이때 우리의 CustomErrorCode를 던지도록 하였습니다.
기존에 MemberNotFoundException 등등 404로 응답되는 경우가 많잖아요 ~
이제 이런 것들을 CustomeErrorCode로 구분해봅시다 ~

Close #244 
