### PR TITLE
fix: API 문서가 보이지 않는 문제 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -74,14 +74,14 @@ tasks.named('asciidoctor') {
 }
 
 asciidoctor.doFirst {
-    delete file('src/main/resources/static/docs')
+    delete file('build/resources/main/static/docs')
 }
 
 task createDocument(type: Copy) {
     dependsOn asciidoctor
 
     from file("build/docs/asciidoc")
-    into file("src/main/resources/static/docs")
+    into file("build/resources/main/static/docs")
 }
 
 bootJar {


### PR DESCRIPTION
## 상세 내용
API 문서인 `index.html`가 생성되면 이 파일을 `build/resources/main/static/docs`로 복사하도록 변경했습니다. 

Close #257 

## 살짝 설명

`Task :processResources`에서 `src/main/resources`의 파일들을 스캔해 `build/resources/main`으로 복사하는 과정이 진행됩니다.

<img width="226" alt="image" src="https://user-images.githubusercontent.com/45311765/184604479-b1734362-915d-4153-8f4b-d22a25dc8ab9.png">

해당 경로에 있어야 마지막의 `Task :bootJar` 과정에서 jar 파일을 만들 때 `build/resources`의 파일들도 함께 포함시킵니다. 

<img width="172" alt="image" src="https://user-images.githubusercontent.com/45311765/184604728-9736ffb0-5ed3-4b42-bd1e-aeceb3740c3c.png">

기존에는 `Task :asciidoctor` 과정에서 `index.html`을 `src/main/resources/static/docs`로 복사했기 때문에 `Task :processResources`과정에서는 `index.html`을 스캔할 수 없었습니다. 그래서 경로를 아예 바꿔버렸습니다ㅋㅋ

[김오찌의 포스팅](https://prolog.techcourse.co.kr/studylogs/2525)을 참고했습니다. 

## 로컬에서 확인

기존의 `index.html`을 모두 지우고 `./gradlew clean` 후 `./gradlew build`를 진행했습니다. 

jar 내에 static 디렉토리가 생성된 것을 확인했습니다. (내부에 index.html 있음!!)
<img width="852" alt="image" src="https://user-images.githubusercontent.com/45311765/184607996-92c4bb7c-8b39-4fe9-a296-11e136681954.png">

