### PR TITLE
feat(modal): 모달 재사용 컴포넌트 구현

### DIFF
--- a/frontend/src/components/@common/Modal/Modal.tsx
+++ b/frontend/src/components/@common/Modal/Modal.tsx
@@ -1,0 +1,43 @@
+import React, { MouseEvent, PropsWithChildren, useRef } from 'react';
+import styled from '@emotion/styled';
+
+interface Props extends PropsWithChildren {
+  visible: boolean;
+  onClose: () => void;
+}
+
+function Modal({ children, visible, onClose }: Props) {
+  const outside = useRef<HTMLDivElement>(null);
+
+  const handleModalClose = (e: MouseEvent<HTMLDivElement>) => {
+    if (outside.current === e.target) {
+      onClose();
+    }
+  };
+
+  return (
+    <StyledModalContainer
+      ref={outside}
+      visible={visible}
+      tabIndex={-1}
+      onClick={handleModalClose}
+    >
+      {children}
+    </StyledModalContainer>
+  );
+}
+
+const StyledModalContainer = styled.div<{visible: boolean}>(({ theme, visible }) => `
+  z-index: 10;
+  display: ${visible ? 'flex' : 'none'};
+  background-color: ${theme.colors.TRANSPARENT_BLACK_100_25};
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100vw;
+`);
+
+export default Modal;

--- a/frontend/src/components/@common/Modal/Modal.tsx
+++ b/frontend/src/components/@common/Modal/Modal.tsx
@@ -2,11 +2,11 @@ import React, { MouseEvent, PropsWithChildren, useRef } from 'react';
 import styled from '@emotion/styled';
 
 interface Props extends PropsWithChildren {
-  visible: boolean;
+  isVisible: boolean;
   onClose: () => void;
 }
 
-function Modal({ children, visible, onClose }: Props) {
+function Modal({ children, isVisible, onClose }: Props) {
   const outside = useRef<HTMLDivElement>(null);
 
   const handleCloseModal = (e: MouseEvent<HTMLDivElement>) => {
@@ -18,7 +18,7 @@ function Modal({ children, visible, onClose }: Props) {
   return (
     <StyledModalContainer
       ref={outside}
-      visible={visible}
+      isVisible={isVisible}
       tabIndex={-1}
       onClick={handleCloseModal}
     >
@@ -27,9 +27,9 @@ function Modal({ children, visible, onClose }: Props) {
   );
 }
 
-const StyledModalContainer = styled.div<{visible: boolean}>(({ theme, visible }) => `
+const StyledModalContainer = styled.div<{isVisible: boolean}>(({ theme, isVisible }) => `
   z-index: 10;
-  display: ${visible ? 'flex' : 'none'};
+  display: ${isVisible ? 'flex' : 'none'};
   background-color: ${theme.colors.TRANSPARENT_BLACK_100_25};
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/@common/Modal/Modal.tsx
+++ b/frontend/src/components/@common/Modal/Modal.tsx
@@ -9,7 +9,7 @@ interface Props extends PropsWithChildren {
 function Modal({ children, visible, onClose }: Props) {
   const outside = useRef<HTMLDivElement>(null);
 
-  const handleModalClose = (e: MouseEvent<HTMLDivElement>) => {
+  const handleCloseModal = (e: MouseEvent<HTMLDivElement>) => {
     if (outside.current === e.target) {
       onClose();
     }
@@ -20,7 +20,7 @@ function Modal({ children, visible, onClose }: Props) {
       ref={outside}
       visible={visible}
       tabIndex={-1}
-      onClick={handleModalClose}
+      onClick={handleCloseModal}
     >
       {children}
     </StyledModalContainer>

--- a/frontend/src/components/@common/Modal/Modal.tsx
+++ b/frontend/src/components/@common/Modal/Modal.tsx
@@ -3,15 +3,15 @@ import styled from '@emotion/styled';
 
 interface Props extends PropsWithChildren {
   isVisible: boolean;
-  onClose: () => void;
+  close: () => void;
 }
 
-function Modal({ children, isVisible, onClose }: Props) {
+function Modal({ children, isVisible, close }: Props) {
   const outside = useRef<HTMLDivElement>(null);
 
   const handleCloseModal = (e: MouseEvent<HTMLDivElement>) => {
     if (outside.current === e.target) {
-      onClose();
+      close();
     }
   };
 


### PR DESCRIPTION
## 상세 내용
- 모달 재사용 컴포넌트를 구현했습니다. 
- 사용법 
```tsx
      <Modal visible={isClickedSlackMenu} onClose={handleSetIsClickedSlackMenu}>
        {/* 실제 모달창에 대한 스타일 */ }
        <StyledSlackModal /> 
      </Modal>
```

- `props`로 전달해주는 값 설명 
  - `children`: children으로 모달 박스를 받습니다. 
  - `visible`: 모달이 보이는지의 여부 (boolean). 이 값에 따라 modal의 display를  flex(true)나 none(false)로 설정합니다. 
  - `onClose`: close될 때 visible의 값을 바꿀 수 있는 함수

Close #266
