### PR TITLE
refactor(core): 존재하지 않는 정적파일 요청 시에도 커스텀 NOT_FOUND 응답을 반환하도록 변경

### DIFF
--- a/backend/src/main/java/com/morak/back/core/config/WebConfig.java
+++ b/backend/src/main/java/com/morak/back/core/config/WebConfig.java
@@ -20,7 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/docs/**")
-                .addResourceLocations("classpath:/static/docs/");
+        registry.addResourceHandler("/docs/index.html")
+                .addResourceLocations("classpath:/static/");
     }
 }

--- a/backend/src/test/java/com/morak/back/core/ui/ApiNotFoundTest.java
+++ b/backend/src/test/java/com/morak/back/core/ui/ApiNotFoundTest.java
@@ -28,4 +28,32 @@ public class ApiNotFoundTest extends AcceptanceTest {
                         .isEqualTo(CustomErrorCode.API_NOT_FOUND_ERROR.getNumber())
         );
     }
+
+    @Test
+    void rest_docs_문서가_요청되면_OK를_응답한다() {
+        // given
+        String resourceApi = "/docs/index.html";
+
+        // when
+        ExtractableResponse<Response> response = SimpleRestAssured.get(resourceApi);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void rest_docs_문서가_아닌_정적파일이_요청되면_NOT_FOUND를_응답한다() {
+        // given
+        String invalidResourceApi = "/docs/index.htm";
+
+        // when
+        ExtractableResponse<Response> response = SimpleRestAssured.get(invalidResourceApi);
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value()),
+                () -> assertThat(SimpleRestAssured.extractCodeNumber(response))
+                        .isEqualTo(CustomErrorCode.API_NOT_FOUND_ERROR.getNumber())
+        );
+    }
 }

--- a/backend/src/test/java/com/morak/back/core/ui/ApiNotFoundTest.java
+++ b/backend/src/test/java/com/morak/back/core/ui/ApiNotFoundTest.java
@@ -30,18 +30,6 @@ public class ApiNotFoundTest extends AcceptanceTest {
     }
 
     @Test
-    void rest_docs_문서가_요청되면_OK를_응답한다() {
-        // given
-        String resourceApi = "/docs/index.html";
-
-        // when
-        ExtractableResponse<Response> response = SimpleRestAssured.get(resourceApi);
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    @Test
     void rest_docs_문서가_아닌_정적파일이_요청되면_NOT_FOUND를_응답한다() {
         // given
         String invalidResourceApi = "/docs/index.htm";


### PR DESCRIPTION
## 상세 내용
존재하지 않는 정적파일 요청시에 커스터 마이징하지 않은 404 에러가 응답되었는데요~ 
이제는 커스터 마이징한 404 에러가 응답될 겁니다.

자세한 내용은 [노션](https://ririhan.notion.site/API-eca7904eea054274a9c44864e19c5b8b) 에 정리했습니다

Close #281 
