### PR TITLE
fix: 팀 초대 코드 만료시간 연장 

### DIFF
--- a/backend/src/main/java/com/morak/back/team/domain/TeamInvitation.java
+++ b/backend/src/main/java/com/morak/back/team/domain/TeamInvitation.java
@@ -61,4 +61,8 @@ public class TeamInvitation extends BaseEntity {
     public String getCode() {
         return code.getCode();
     }
+
+    public LocalDateTime getExpiredAt() {
+        return expiredAt.getExpiredAt();
+    }
 }

--- a/backend/src/main/java/com/morak/back/team/domain/TeamInvitation.java
+++ b/backend/src/main/java/com/morak/back/team/domain/TeamInvitation.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TeamInvitation extends BaseEntity {
 
-    private static final long EXPIRED_MINUTES = 30L;
+    private static final long DEFAULT_EXPIRED_MINUTES = 2 * 24 * 60L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,10 +44,14 @@ public class TeamInvitation extends BaseEntity {
         this.id = id;
         this.team = team;
         this.code = code;
-        this.expiredAt = expiredAt;
+        this.expiredAt = initializeExpiredAt(expiredAt);
+    }
+
+    private ExpiredTime initializeExpiredAt(ExpiredTime expiredAt) {
         if (expiredAt == null) {
-            this.expiredAt = ExpiredTime.withMinute(EXPIRED_MINUTES);
+            return ExpiredTime.withMinute(DEFAULT_EXPIRED_MINUTES);
         }
+        return expiredAt;
     }
 
     public boolean isExpired() {

--- a/backend/src/test/java/com/morak/back/team/domain/TeamInvitationTest.java
+++ b/backend/src/test/java/com/morak/back/team/domain/TeamInvitationTest.java
@@ -3,9 +3,26 @@ package com.morak.back.team.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.morak.back.core.domain.Code;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 class TeamInvitationTest {
+
+    @Test
+    void 만료시간을_설정하지_않으면_기본시간인_2일로_설정된다() {
+        // given
+        LocalDateTime before = LocalDateTime.now().plusDays(2);
+
+        // when
+        TeamInvitation teamInvitation = TeamInvitation.builder()
+                .code(Code.generate(length -> "abcd1234"))
+                .build();
+
+        // then
+        LocalDateTime after = LocalDateTime.now().plusDays(2);
+
+        assertThat(teamInvitation.getExpiredAt()).isBetween(before, after);
+    }
 
     @Test
     void 만료되지_않은_시간인지_확인한다() {


### PR DESCRIPTION
## 상세 내용

초대 코드 만료시간 30분은 너무 오바라 2일로 연장했습니다. 
추후 프론트 측에서 사용자에게 초대 코드의 만료시간을 명시해주거나, 만료시간을 설정할 수 있도록 개선해 볼 수 있을 것 같습니다. 

Close #273 
