### PR TITLE
fix(group): 그룹 랜덤 프로필을 그룹 리스트에도 보여주도록 수정 

### DIFF
--- a/frontend/src/components/SidebarGroupMenu/SidebarGroupMenu.tsx
+++ b/frontend/src/components/SidebarGroupMenu/SidebarGroupMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, CSSProperties } from 'react';
 import styled from '@emotion/styled';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import Setting from '../../assets/setting.svg';
 import Menu from '../../assets/menu.svg';
 import Plus from '../../assets/plus.svg';
@@ -41,6 +41,10 @@ function SidebarGroupMenu({ onClickCreateMenu, onClickParticipateMenu, groupCode
     dispatch({ type: 'SET_SHOW_GROUP_LIST', payload: !isVisibleGroups });
   };
 
+  const handleMoveToGroup = (groupCode: GroupInterface['code']) => () => {
+    navigate(`groups/${groupCode}`);
+    handleToggleisVisibleGroups();
+  };
   const getRandomPastelColor = () => `hsl(${360 * Math.random()},${
     25 + 70 * Math.random()}%,${
     85 + 10 * Math.random()}%)`;
@@ -79,7 +83,10 @@ function SidebarGroupMenu({ onClickCreateMenu, onClickParticipateMenu, groupCode
       <StyledGroupListBox isVisible={isVisibleGroups}>
         <StyledGroupListContainer>
           {groups.map((group) => (
-            <StyledGroupList to={`groups/${group.code}`} isNowGroup={groupCode === group.code}>
+            <StyledGroupList
+              onClick={handleMoveToGroup(group.code)}
+              isNowGroup={groupCode === group.code}
+            >
               <StyledGroupProfile
                 backgroundColor={groupCode === group.code ? profileColor : getRandomPastelColor()}
               >
@@ -173,12 +180,6 @@ const StyledGroupFirstName = styled.div(({ theme }) => `
   font-size: 4.8rem;
 `);
 
-const StyledGroupListImage = styled.img`
-  width: 5.2rem;
-  height: 5.2rem;
-  border-radius: 0.8rem;
-`;
-
 const StyledGroupTitle = styled.div`
   font-size: 1.6rem;
   margin-bottom: 1.2rem;
@@ -190,7 +191,7 @@ position: relative;
   margin-bottom: 2.8rem;
 `;
 
-const StyledGroupList = styled(Link)<{ isNowGroup: boolean }>(
+const StyledGroupList = styled.div<{ isNowGroup: boolean }>(
   ({ theme, isNowGroup }) => `
   display: flex;
   gap: 2rem;
@@ -198,12 +199,20 @@ const StyledGroupList = styled(Link)<{ isNowGroup: boolean }>(
   text-decoration: none;
   margin: 1.2rem;
   color: ${theme.colors.BLACK_100};
+  cursor: pointer;
+
+  &:hover {
+    background: ${theme.colors.TRANSPARENT_GRAY_100_80};
+    border-radius: 10px;
+    transition: all 0.2s linear;
+  }
 
   ${isNowGroup
     && `
     background: ${theme.colors.GRAY_100}; 
     border-radius: 10px;
     `
+
 }
 `
 );

--- a/frontend/src/components/SidebarGroupMenu/SidebarGroupMenu.tsx
+++ b/frontend/src/components/SidebarGroupMenu/SidebarGroupMenu.tsx
@@ -41,9 +41,11 @@ function SidebarGroupMenu({ onClickCreateMenu, onClickParticipateMenu, groupCode
     dispatch({ type: 'SET_SHOW_GROUP_LIST', payload: !isVisibleGroups });
   };
 
-  const handleMoveToGroup = (groupCode: GroupInterface['code']) => () => {
-    navigate(`groups/${groupCode}`);
-    handleToggleisVisibleGroups();
+  const handleMoveToGroup = (groupCode: GroupInterface['code'], groupName: GroupInterface['name']) => () => {
+    if (confirm(`${groupName} 그룹으로 이동하시겠습니까?`)) {
+      navigate(`groups/${groupCode}`);
+      handleToggleisVisibleGroups();
+    }
   };
   const getRandomPastelColor = () => `hsl(${360 * Math.random()},${
     25 + 70 * Math.random()}%,${
@@ -84,7 +86,7 @@ function SidebarGroupMenu({ onClickCreateMenu, onClickParticipateMenu, groupCode
         <StyledGroupListContainer>
           {groups.map((group) => (
             <StyledGroupList
-              onClick={handleMoveToGroup(group.code)}
+              onClick={handleMoveToGroup(group.code, group.name)}
               isNowGroup={groupCode === group.code}
             >
               <StyledGroupProfile

--- a/frontend/src/components/SidebarGroupMenu/SidebarGroupMenu.tsx
+++ b/frontend/src/components/SidebarGroupMenu/SidebarGroupMenu.tsx
@@ -80,7 +80,11 @@ function SidebarGroupMenu({ onClickCreateMenu, onClickParticipateMenu, groupCode
         <StyledGroupListContainer>
           {groups.map((group) => (
             <StyledGroupList to={`groups/${group.code}`} isNowGroup={groupCode === group.code}>
-              <StyledGroupListImage src="https://us.123rf.com/450wm/zoomzoom/zoomzoom1803/zoomzoom180300055/97726350-%EB%B9%9B-%EA%B5%AC%EB%A6%84%EA%B3%BC-%ED%91%B8%EB%A5%B8-%EB%B4%84-%ED%95%98%EB%8A%98.jpg?ver=6" />
+              <StyledGroupProfile
+                backgroundColor={groupCode === group.code ? profileColor : getRandomPastelColor()}
+              >
+                <StyledGroupFirstName>{group && group.name[0]}</StyledGroupFirstName>
+              </StyledGroupProfile>
               <FlexContainer flexDirection="column">
                 <StyledGroupTitle>{group.name}</StyledGroupTitle>
               </FlexContainer>


### PR DESCRIPTION
## 상세 내용
- 그룹 랜덤 프로필을 그룹 리스트에도 보여주도록 수정했습니다. 
- 다만, 그룹별로 배경 color를 프론트측에서 저장해주지 않고 있기 때문에 그룹별로 컬러가 항상 같은 것으로 고정되어있지는 않습니다. 이후 그룹 프로필을 사용자가 직접 지정하고, api에 group profile을 저장하는 것으로 변경이 되면 로직을 수정하겠습니다 😄 

Close #330 
