### PR TITLE
refactor: 데스크탑에서 깨지지 않도록 스타일 수정 

### DIFF
--- a/frontend/src/components/@common/Select/Select.tsx
+++ b/frontend/src/components/@common/Select/Select.tsx
@@ -7,10 +7,11 @@ function Select({ children, ...props }: Props & CSSProperties) {
   return <StyledSelect {...props}>{children}</StyledSelect>;
 }
 
-const StyledSelect = styled.select<CSSProperties>`
+const StyledSelect = styled.select<CSSProperties>(
+  ({fontSize}) => `
   appearance: none;
   width: 100%;
-  font-size: 2.8rem;
+  font-size: ${fontSize ||  "2.8rem"};
   text-align: center;
   border: none;
   cursor: pointer;
@@ -18,6 +19,6 @@ const StyledSelect = styled.select<CSSProperties>`
   :focus {
     outline: none;
   }
-`;
+`);
 
 export default Select;

--- a/frontend/src/components/AppointmentCreate/AppointmentCreateForm/AppointmentCreateForm.tsx
+++ b/frontend/src/components/AppointmentCreate/AppointmentCreateForm/AppointmentCreateForm.tsx
@@ -114,7 +114,7 @@ function AppointmentCreateForm({ startDate, endDate }: Props) {
   return (
     <StyledForm onSubmit={handleCreateAppointment}>
       <Box width="66rem" minHeight="56.4rem" padding="4.8rem">
-        <FlexContainer flexDirection="column" gap="1.6rem">
+        <FlexContainer flexDirection="column" gap="2rem">
           <AppointmentCreateFormTitleInput title={title} onChange={handleTitle} />
           <AppointmentCreateFormDescriptionInput
             description={description}

--- a/frontend/src/components/AppointmentCreate/AppointmentCreateFormButtonGroup/AppointmentCreateFormButtonGroup.tsx
+++ b/frontend/src/components/AppointmentCreate/AppointmentCreateFormButtonGroup/AppointmentCreateFormButtonGroup.tsx
@@ -11,7 +11,7 @@ function AppointmentCreateFormButtonGroup({ onCancel }: Props) {
   const theme = useTheme();
 
   return (
-    <FlexContainer justifyContent="center" gap="0.8rem">
+    <FlexContainer justifyContent="space-between">
       <Button
         variant="filled"
         colorScheme={theme.colors.GRAY_400}

--- a/frontend/src/components/AppointmentCreate/AppointmentCreateFormCloseTimeInput/AppointmentCreateFormCloseTimeInput.tsx
+++ b/frontend/src/components/AppointmentCreate/AppointmentCreateFormCloseTimeInput/AppointmentCreateFormCloseTimeInput.tsx
@@ -25,7 +25,7 @@ function AppointmentCreateFormCloseTimeInput({
 
   return (
     <>
-      <StyledLabel>마감 시간 설정</StyledLabel>
+      <StyledTitle>마감 시간 설정</StyledTitle>
       <TextField
         variant="outlined"
         colorScheme={theme.colors.PURPLE_100}
@@ -40,19 +40,19 @@ function AppointmentCreateFormCloseTimeInput({
             max={maxCloseDate}
             onChange={onChangeDate}
             value={closeDate}
-            fontSize="2rem"
+            fontSize="2.4rem"
             required
           />
-          <Input type="time" onChange={onChangeTime} value={closeTime} fontSize="2rem" required />
+          <Input type="time" onChange={onChangeTime} value={closeTime} fontSize="2.4rem" required />
         </FlexContainer>
       </TextField>
     </>
   );
 }
 
-const StyledLabel = styled.label(
+const StyledTitle = styled.div(
   ({ theme }) => `
-  font-size: 4rem;
+  font-size: 2.8rem;
   color: ${theme.colors.PURPLE_100};
 `
 );

--- a/frontend/src/components/AppointmentCreate/AppointmentCreateFormDescriptionInput/AppointmentCreateFormDescriptionInput.tsx
+++ b/frontend/src/components/AppointmentCreate/AppointmentCreateFormDescriptionInput/AppointmentCreateFormDescriptionInput.tsx
@@ -14,7 +14,7 @@ function AppointmentCreateFormDescriptionInput({ description, onChange }: Props)
       <Input
         id="appointment-description"
         placeholder="약속에 대한 설명을 입력해주세요"
-        fontSize="3.2rem"
+        fontSize="2.4rem"
         textAlign="start"
         value={description}
         onChange={onChange}
@@ -26,7 +26,7 @@ function AppointmentCreateFormDescriptionInput({ description, onChange }: Props)
 
 const StyledLabel = styled.label(
   ({ theme }) => `
-  font-size: 4rem;
+  font-size: 2.8rem;
   color: ${theme.colors.PURPLE_100};
 `
 );

--- a/frontend/src/components/AppointmentCreate/AppointmentCreateFormDurationInput/AppointmentCreateFormDurationInput.tsx
+++ b/frontend/src/components/AppointmentCreate/AppointmentCreateFormDurationInput/AppointmentCreateFormDurationInput.tsx
@@ -43,7 +43,7 @@ function AppointmentCreateFormDurationInput({ duration, onChange }: Props) {
         padding="0.4rem 0.8rem"
         width="9.2rem"
       >
-        <Select id="minute" onChange={onChange} value={minute} name="minute" required>
+        <Select id="minute" onChange={onChange} value={minute} name="minute" fontSize="2.4rem" required>
           <option value="00">00</option>
           <option value="30">30</option>
         </Select>
@@ -55,11 +55,11 @@ function AppointmentCreateFormDurationInput({ duration, onChange }: Props) {
 }
 
 const StyledContent = styled.p`
-  font-size: 3.2rem;
+  font-size: 2.8rem;
 `;
 
 const StyledLabel = styled.label`
-  font-size: 3.2rem;
+  font-size: 2.8rem;
 `;
 
 export default AppointmentCreateFormDurationInput;

--- a/frontend/src/components/AppointmentCreate/AppointmentCreateFormTimeInput/AppointmentCreateFormTimeInput.tsx
+++ b/frontend/src/components/AppointmentCreate/AppointmentCreateFormTimeInput/AppointmentCreateFormTimeInput.tsx
@@ -25,11 +25,11 @@ function AppointmentCreateFormTimeInput({ time, onChange }: Props) {
     >
       <FlexContainer alignItems="center">
         {/* TODO: label을 어떻게 넣을것인가? 빈값으로? */}
-        <Select name="period" value={time.period} onChange={onChange} required>
+        <Select name="period" value={time.period} onChange={onChange} fontSize="2.4rem" required>
           <option value="AM">AM</option>
           <option value="PM">PM</option>
         </Select>
-        <Select name="hour" value={time.hour} onChange={onChange} required>
+        <Select name="hour" value={time.hour} onChange={onChange} fontSize="2.4rem" required>
           <option value="">--</option>
           {createRange({
             size: 12,
@@ -41,7 +41,7 @@ function AppointmentCreateFormTimeInput({ time, onChange }: Props) {
           ))}
         </Select>
         <StyledContent>:</StyledContent>
-        <Select name="minute" value={time.minute} onChange={onChange} required>
+        <Select name="minute" value={time.minute} onChange={onChange} fontSize="2.4rem" required>
           <option value="00">00</option>
           <option value="30">30</option>
         </Select>
@@ -51,7 +51,7 @@ function AppointmentCreateFormTimeInput({ time, onChange }: Props) {
 }
 
 const StyledContent = styled.p`
-  font-size: 3.2rem;
+  font-size: 2.4rem;
 `;
 
 export default AppointmentCreateFormTimeInput;

--- a/frontend/src/components/AppointmentCreate/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
+++ b/frontend/src/components/AppointmentCreate/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
@@ -19,7 +19,7 @@ function AppointmentCreateFormTimeLimitInput({
 }: Props) {
   return (
     <>
-      <StyledLabel>가능 시간 제한</StyledLabel>
+      <StyledTitle>가능 시간 제한 설정</StyledTitle>
       <StyledHelperText>AM 12:00 ~ AM 12:00(다음날)은 하루종일을 의미합니다.</StyledHelperText>
       <FlexContainer alignItems="center" gap="2.8rem">
         <AppointmentCreateFormTimeInput time={startTime} onChange={onChangeStartTime} />
@@ -30,19 +30,19 @@ function AppointmentCreateFormTimeLimitInput({
   );
 }
 
-const StyledLabel = styled.label(
+const StyledTitle = styled.div(
   ({ theme }) => `
-  font-size: 4rem;
+  font-size: 2.8rem;
   color: ${theme.colors.PURPLE_100};
 `
 );
 
 const StyledContent = styled.p`
-  font-size: 3.2rem;
+  font-size: 2.4rem;
 `;
 
 const StyledHelperText = styled.p`
-  font-size: 1.6rem;
+  font-size: 2rem;
 `;
 
 export default AppointmentCreateFormTimeLimitInput;

--- a/frontend/src/components/AppointmentCreate/AppointmentCreateFormTitleInput/AppointmentCreateFormTitleInput.tsx
+++ b/frontend/src/components/AppointmentCreate/AppointmentCreateFormTitleInput/AppointmentCreateFormTitleInput.tsx
@@ -14,7 +14,7 @@ function AppointmentCreateFormTitleInput({ title, onChange }: Props) {
       <Input
         id="appointment-title"
         placeholder="약속 제목을 입력해주세요"
-        fontSize="3.2rem"
+        fontSize="2.4rem"
         textAlign="start"
         value={title}
         onChange={onChange}
@@ -27,7 +27,7 @@ function AppointmentCreateFormTitleInput({ title, onChange }: Props) {
 
 const StyledLabel = styled.label(
   ({ theme }) => `
-  font-size: 4rem;
+  font-size: 2.8rem;
   color: ${theme.colors.PURPLE_100};
 `
 );

--- a/frontend/src/components/AppointmentMain/AppointmentMainButtonGroup/AppointmentMainButtonGroup.tsx
+++ b/frontend/src/components/AppointmentMain/AppointmentMainButtonGroup/AppointmentMainButtonGroup.tsx
@@ -22,8 +22,8 @@ function AppointmentMainButtonGroup({ appointmentCode, isClosed }: Props) {
       {!isClosed && (
         <Button
           variant="filled"
-          width="6rem"
-          padding="0.4rem 0"
+          width="8.4rem"
+          padding="0.8rem 0"
           fontSize="1.2rem"
           borderRadius="5px"
           colorScheme={theme.colors.PURPLE_100}
@@ -34,8 +34,8 @@ function AppointmentMainButtonGroup({ appointmentCode, isClosed }: Props) {
       )}
       <Button
         variant="outlined"
-        width="6rem"
-        padding="0.4rem 0"
+        width="8.4rem"
+        padding="0.8rem 0"
         fontSize="1.2rem"
         borderRadius="5px"
         colorScheme={theme.colors.PURPLE_100}

--- a/frontend/src/components/AppointmentMain/AppointmentMainContainer/AppointmentMainContainer.tsx
+++ b/frontend/src/components/AppointmentMain/AppointmentMainContainer/AppointmentMainContainer.tsx
@@ -49,9 +49,9 @@ function AppointmentMainContainer() {
           ({ code, title, durationHours, durationMinutes, count, isClosed, closedAt }) => (
             <Box
               key={code}
-              width="26.4rem"
-              padding="2rem"
-              minHeight="16.8rem"
+              width="36.4rem"
+              padding="2.8rem"
+              minHeight="23.2rem"
               filter={isClosed ? 'grayscale(1)' : 'none'}
             >
               <FlexContainer justifyContent="end">
@@ -61,7 +61,7 @@ function AppointmentMainContainer() {
               <MarginContainer margin="0 0 0.4rem">
                 <AppointmentMainProgress count={count} groupCode={groupCode} />
               </MarginContainer>
-              <MarginContainer margin="0 0 1.2rem">
+              <MarginContainer margin="0 0 1.6rem">
                 <AppointmentMainDetail
                   durationHours={durationHours}
                   durationMinutes={durationMinutes}
@@ -77,13 +77,13 @@ function AppointmentMainContainer() {
 }
 
 const StyledContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 2.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3.2rem;
 `;
 
 const StyledTitle = styled.h1`
-  font-size: 1.6rem;
+  font-size: 2.2rem;
   text-align: center;
 `;
 
@@ -96,7 +96,7 @@ const LottieWrapper = styled.div`
 const StyledGuide = styled.p(
   ({ theme }) => `
   text-align: center;
-  font-size: 2.8rem;
+  font-size: 4rem;
 
   color: ${theme.colors.GRAY_400}
 `

--- a/frontend/src/components/AppointmentMain/AppointmentMainDetail/AppointmentMainDetail.tsx
+++ b/frontend/src/components/AppointmentMain/AppointmentMainDetail/AppointmentMainDetail.tsx
@@ -29,16 +29,16 @@ function AppointmentMainDetail({ durationHours, durationMinutes, closedAt }: Pro
   const theme = useTheme();
 
   return (
-    <FlexContainer flexDirection="column" gap="1.2rem">
+    <FlexContainer flexDirection="column" gap="1.6rem">
       <StyledCloseTime>
         {getFormattedClosedTime(closedAt)}
         까지
       </StyledCloseTime>
       <TextField
-        width="5.2rem"
+        width="7.2rem"
         borderRadius="20px"
         variant="outlined"
-        padding="0.4rem 0"
+        padding="0.8rem 0"
         colorScheme={theme.colors.PURPLE_100}
       >
         <StyledDetail>
@@ -52,14 +52,14 @@ function AppointmentMainDetail({ durationHours, durationMinutes, closedAt }: Pro
 }
 
 const StyledCloseTime = styled.p`
-  font-size: 0.8rem;
+  font-size: 1.4rem;
   align-self: end;
 `;
 
 const StyledDetail = styled.span(
   ({ theme }) => `
   color: ${theme.colors.PURPLE_100};
-  font-size: 0.8rem;
+  font-size: 1.2rem;
 `
 );
 

--- a/frontend/src/components/AppointmentMain/AppointmentMainHeader/AppointmentMainHeader.tsx
+++ b/frontend/src/components/AppointmentMain/AppointmentMainHeader/AppointmentMainHeader.tsx
@@ -19,11 +19,12 @@ function AppointmentMainHeader() {
       <FlexContainer justifyContent="space-between">
         <StyledTitle>약속잡기 목록</StyledTitle>
         <Button
-          width="12rem"
+          width="16rem"
           colorScheme={theme.colors.PURPLE_100}
           variant="filled"
           onClick={handleNavigate('create')}
-          fontSize="1.6rem"
+          fontSize="2rem"
+          padding="1.6rem 0"
         >
           약속 생성하기
         </Button>

--- a/frontend/src/components/AppointmentMain/AppointmentMainProgress/AppointmentMainProgress.tsx
+++ b/frontend/src/components/AppointmentMain/AppointmentMainProgress/AppointmentMainProgress.tsx
@@ -47,7 +47,7 @@ function AppointmentMainProgress({ count, groupCode }: Props) {
 }
 
 const StyledParticipantsStatus = styled.p`
-  font-size: 0.8rem;
+  font-size: 1.6rem;
 `;
 
 export default AppointmentMainProgress;

--- a/frontend/src/components/AppointmentMain/AppointmentMainStatus/AppointmentMainStatus.tsx
+++ b/frontend/src/components/AppointmentMain/AppointmentMainStatus/AppointmentMainStatus.tsx
@@ -12,8 +12,8 @@ function AppointmentMainStatus({ isClosed }: Props) {
   return (
     <TextField
       variant="filled"
-      width="4rem"
-      padding="0.4rem 0"
+      width="7.2rem"
+      padding="0.8rem 0"
       borderRadius="5px"
       colorScheme={!isClosed ? theme.colors.PURPLE_100 : theme.colors.GRAY_400}
     >
@@ -25,6 +25,7 @@ function AppointmentMainStatus({ isClosed }: Props) {
 const StyledStatus = styled.span(
   ({ theme }) => `
   color: ${theme.colors.WHITE_100};
+  font-size: 1.2rem;
 `
 );
 

--- a/frontend/src/components/AppointmentProgress/AppointmentProgressDetail/AppointmentProgressDetail.tsx
+++ b/frontend/src/components/AppointmentProgress/AppointmentProgressDetail/AppointmentProgressDetail.tsx
@@ -11,26 +11,15 @@ interface Props {
 
 function AppointmentProgressDetail({ durationHours, durationMinutes, startTime, endTime }: Props) {
   return (
-    <>
       <StyledDuration>
-        {durationHours}
-        시간
-        {durationMinutes}
-        분동안 진행
+        약속시간은 {durationHours}시간 {durationMinutes}분동안 진행 
+        <br/>({startTime}~{endTime})
       </StyledDuration>
-      <StyledTimeRange>
-        {startTime}~{endTime}
-      </StyledTimeRange>
-    </>
   );
 }
 
 const StyledDuration = styled.p`
-  font-size: 4rem;
-`;
-
-const StyledTimeRange = styled.p`
-  font-size: 3.2rem;
+  font-size: 2.4rem;
 `;
 
 export default AppointmentProgressDetail;

--- a/frontend/src/components/AppointmentProgress/AppointmentProgressHeader/AppointmentProgressHeader.tsx
+++ b/frontend/src/components/AppointmentProgress/AppointmentProgressHeader/AppointmentProgressHeader.tsx
@@ -1,17 +1,23 @@
 import styled from '@emotion/styled';
 
 import { AppointmentInterface } from '../../../types/appointment';
+import AppointmentProgressDetail from '../../../components/AppointmentProgress/AppointmentProgressDetail/AppointmentProgressDetail';
 
 interface Props {
-  title: AppointmentInterface['title'];
-  description: AppointmentInterface['description'];
+  appointment: AppointmentInterface;
 }
 
-function AppointmentProgressHeader({ title, description }: Props) {
+function AppointmentProgressHeader({ appointment }: Props) {
   return (
     <StyledHeaderContainer>
-      <StyledHeader>{title}</StyledHeader>
-      <StyledDescription>{description}</StyledDescription>
+      <StyledHeader>{appointment.title}</StyledHeader>
+      <StyledDescription>{appointment.description}</StyledDescription>
+      <AppointmentProgressDetail
+          durationHours={appointment.durationHours}
+          durationMinutes={appointment.durationMinutes}
+          startTime={appointment.startTime}
+          endTime={appointment.endTime}
+        />
     </StyledHeaderContainer>
   );
 }
@@ -19,9 +25,8 @@ function AppointmentProgressHeader({ title, description }: Props) {
 const StyledHeaderContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 3.6rem;
+  gap: 2rem;
   max-height: 20.8rem;
-  /* min-height: 20.8rem; */
 `;
 
 const StyledHeader = styled.header`
@@ -29,7 +34,7 @@ const StyledHeader = styled.header`
 `;
 
 const StyledDescription = styled.div`
-  font-size: 2rem;
+  font-size: 2.4rem;
   overflow-y: auto;
 `;
 

--- a/frontend/src/components/AppointmentProgress/AppointmentProgressTimePicker/AppointmentProgressTimePicker.tsx
+++ b/frontend/src/components/AppointmentProgress/AppointmentProgressTimePicker/AppointmentProgressTimePicker.tsx
@@ -95,10 +95,10 @@ function AppointmentProgressTimePicker({
 
   return (
     // TODO: box minheight 없애야할듯
-    <Box width="30rem" minHeight="52rem" height="52rem" padding="3.6rem 2rem" overflow="auto">
+    <Box width="30rem" minHeight="52rem" height="60rem" padding="3.6rem 2rem" overflow="auto">
       <FlexContainer flexDirection="column" gap="1.2rem">
         {!selectedDate ? (
-          <StyledGuideText>왼쪽에서 날짜를 선택해주세요~</StyledGuideText>
+          <StyledGuideText>왼쪽에서 날짜를 선택해주세요</StyledGuideText>
         ) : (
           <>
             {times.map(({ start, end }) => {
@@ -130,9 +130,9 @@ function AppointmentProgressTimePicker({
 const StyledTime = styled.div<{ isSelected: boolean }>(
   ({ theme, isSelected }) => `
   width: 25.6rem;
-  font-size: 1.6rem;
+  font-size: 2rem;
   text-align: center;
-  padding: 0.8rem 0;
+  padding: 1.2rem 0;
   border-radius: 10px;
   cursor: pointer;
 

--- a/frontend/src/components/AppointmentResult/AppointmentResultRanking/AppointmentResultRanking.tsx
+++ b/frontend/src/components/AppointmentResult/AppointmentResultRanking/AppointmentResultRanking.tsx
@@ -77,7 +77,7 @@ function AppointmentResultRanking({
             onClick={onClickRank(idx)}
             isClicked={idx === clickedRecommendation}
           >
-            <FlexContainer justifyContent="space-between">
+            <FlexContainer justifyContent="space-between" alignItems="center">
               {/* TODO: 상수화 */}
               {rank === 1 ? (
                 <StyledCrownIcon src={Crown} alt="crown" />
@@ -86,7 +86,7 @@ function AppointmentResultRanking({
                 <StyledResultText>{rank}</StyledResultText>
               )}
               <StyledResultText>
-                {getDateTime(recommendStartDateTime)}~{getDateTime(recommendEndDateTime)}
+                {getDateTime(recommendStartDateTime)}<br/>~{getDateTime(recommendEndDateTime)}
               </StyledResultText>
               <StyledResultText>
                 {availableMembers.length}/{totalParticipants}명 가능

--- a/frontend/src/components/AppointmentResult/AppointmentResultStatus/AppointmentResultStatus.tsx
+++ b/frontend/src/components/AppointmentResult/AppointmentResultStatus/AppointmentResultStatus.tsx
@@ -13,7 +13,7 @@ function AppointmentResultStatus({ isClosed }: Props) {
   return (
     <TextField
       variant="filled"
-      width="6.8rem"
+      width="12.8rem"
       padding="1.6rem 0"
       borderRadius="1.2rem"
       colorScheme={isClosed ? theme.colors.GRAY_400 : theme.colors.PURPLE_100}
@@ -26,7 +26,7 @@ function AppointmentResultStatus({ isClosed }: Props) {
 const StyledStatus = styled.span(
   ({ theme }) => `
   color: ${theme.colors.WHITE_100};
-  font-size: 1.6rem;
+  font-size: 2.4rem;
 `
 );
 

--- a/frontend/src/components/PollCreate/PollCreateCloseTimeInput/PollCreateCloseTimeInput.tsx
+++ b/frontend/src/components/PollCreate/PollCreateCloseTimeInput/PollCreateCloseTimeInput.tsx
@@ -35,8 +35,7 @@ function PollCreateCloseTimeInput({ closingTime, closingDate, onChangeTime, onCh
 const StyledLabel = styled.label(
   ({ theme }) => `
   font-size: 1.6rem;
-
-  color: ${theme.colors.GRAY_400}
+  color: ${theme.colors.GRAY_400};
 `
 );
 export default PollCreateCloseTimeInput;

--- a/frontend/src/components/PollCreate/PollCreateDetail/PollCreateDetail.tsx
+++ b/frontend/src/components/PollCreate/PollCreateDetail/PollCreateDetail.tsx
@@ -26,7 +26,7 @@ function PollCreateDetail({
           width="6.4rem"
           borderRadius="20px"
           variant="outlined"
-          fontSize="0.8rem"
+          fontSize="1.2rem"
           colorScheme={isAnonymous ? theme.colors.GRAY_400 : theme.colors.PURPLE_100}
           onClick={handleAnonymous(false)}
         >
@@ -36,7 +36,7 @@ function PollCreateDetail({
           width="6.4rem"
           borderRadius="20px"
           variant="outlined"
-          fontSize="0.8rem"
+          fontSize="1.2rem"
           colorScheme={isAnonymous ? theme.colors.PURPLE_100 : theme.colors.GRAY_400}
           onClick={handleAnonymous(true)}
         >
@@ -45,20 +45,20 @@ function PollCreateDetail({
       </FlexContainer>
       <FlexContainer gap="1.2rem">
         <Button
-          width="9.2rem"
+          width="11.2rem"
           borderRadius="20px"
           variant="outlined"
-          fontSize="0.8rem"
+          fontSize="1.2rem"
           colorScheme={isAllowedMultiplePollCount ? theme.colors.GRAY_400 : theme.colors.PURPLE_100}
           onClick={handleAllowedMultiplePollCount(false)}
         >
           하나만 투표 가능
         </Button>
         <Button
-          width="9.2rem"
+          width="11.2rem"
           borderRadius="20px"
           variant="outlined"
-          fontSize="0.8rem"
+          fontSize="1.2rem"
           colorScheme={isAllowedMultiplePollCount ? theme.colors.PURPLE_100 : theme.colors.GRAY_400}
           onClick={handleAllowedMultiplePollCount(true)}
         >

--- a/frontend/src/components/PollCreate/PollCreateForm/PollCreateForm.tsx
+++ b/frontend/src/components/PollCreate/PollCreateForm/PollCreateForm.tsx
@@ -75,7 +75,7 @@ function PollCreateForm() {
   };
 
   return (
-    <Box width="84.4rem" padding="4.8rem 4.8rem 14rem">
+    <Box width="84.4rem" padding="6.4rem 4.8rem">
       <form onSubmit={handleSubmit}>
         <PollCreateCloseTimeInput
           closingDate={closingDate}
@@ -83,7 +83,7 @@ function PollCreateForm() {
           onChangeDate={handleCloseDate}
           onChangeTime={handleCloseTime}
         />
-        <MarginContainer margin="0 0 4rem 0">
+        <MarginContainer margin="0 0 4.4rem 0">
           <PollCreateFormTitleInput title={title} onChange={handleTitle} />
           <Divider />
         </MarginContainer>

--- a/frontend/src/components/PollCreate/PollCreateFormInputGroup/PollCreateFormInputGroup.tsx
+++ b/frontend/src/components/PollCreate/PollCreateFormInputGroup/PollCreateFormInputGroup.tsx
@@ -73,7 +73,7 @@ function PollCreateFormInputGroup({ pollItems, setPollItems }: Props) {
               id={pollItem}
               value={pollItem}
               color={theme.colors.BLACK_100}
-              fontSize="1.2rem"
+              fontSize="1.6rem"
               placeholder="선택항목을 입력해주세요!"
               onChange={handleChange(idx)}
               aria-label={`poll-input${idx}`}

--- a/frontend/src/components/PollCreate/PollCreateFormSubmitButton/PollCreateFormSubmitButton.tsx
+++ b/frontend/src/components/PollCreate/PollCreateFormSubmitButton/PollCreateFormSubmitButton.tsx
@@ -10,7 +10,7 @@ function PollCreateFormSubmitButton() {
     <FlexContainer justifyContent="center">
       <Button
         variant="filled"
-        width="46rem"
+        width="100%"
         padding="2rem 0"
         colorScheme={theme.colors.PURPLE_100}
         fontSize="2rem"

--- a/frontend/src/components/PollMain/PollMainButtonGroup/PollMainButtonGroup.tsx
+++ b/frontend/src/components/PollMain/PollMainButtonGroup/PollMainButtonGroup.tsx
@@ -23,8 +23,8 @@ function PollMainButtonGroup({ pollCode, status }: Props) {
         <Button
           type="button"
           variant="filled"
-          width="6rem"
-          padding="0.4rem 0"
+          width="8.4rem"
+          padding="0.8rem 0"
           fontSize="1.2rem"
           borderRadius="5px"
           colorScheme={theme.colors.PURPLE_100}
@@ -36,8 +36,8 @@ function PollMainButtonGroup({ pollCode, status }: Props) {
       <Button
         type="button"
         variant="outlined"
-        width="6rem"
-        padding="0.4rem 0"
+        width="8.4rem"
+        padding="0.8rem 0"
         fontSize="1.2rem"
         borderRadius="5px"
         colorScheme={theme.colors.PURPLE_100}

--- a/frontend/src/components/PollMain/PollMainContainer/PollMainContainer.tsx
+++ b/frontend/src/components/PollMain/PollMainContainer/PollMainContainer.tsx
@@ -50,9 +50,9 @@ function PollMainContainer() {
         polls.map(({ status, title, code, isAnonymous, allowedPollCount, closedAt, count }) => (
           <Box
             key={code}
-            width="26.4rem"
-            padding="2rem"
-            minHeight="16.8rem"
+            width="36.4rem"
+            padding="2.8rem"
+            minHeight="23.2rem"
             filter={status === 'CLOSED' ? 'grayscale(1)' : 'none'}
           >
             <FlexContainer justifyContent="end">
@@ -60,7 +60,7 @@ function PollMainContainer() {
             </FlexContainer>
             <StyledTitle>{title}</StyledTitle>
             <PollMainProgress currentParticipants={count} groupCode={groupCode} />
-            <MarginContainer margin="0 0 1.2rem">
+            <MarginContainer margin="0 0 1.6rem">
               {/* TODO: 'detail' 컴포넌트명 변경 고민(전체 페이지 수정 필요) */}
               <PollMainDetail
                 isAnonymous={isAnonymous}
@@ -76,13 +76,13 @@ function PollMainContainer() {
 }
 
 const StyledContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 2.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3.2rem;
 `;
 
 const StyledTitle = styled.h1`
-  font-size: 1.6rem;
+  font-size: 2.2rem;
   text-align: center;
 `;
 
@@ -95,7 +95,7 @@ const LottieWrapper = styled.div`
 const StyledGuide = styled.p(
   ({ theme }) => `
   text-align: center;
-  font-size: 2.8rem;
+  font-size: 4rem;
 
   color: ${theme.colors.GRAY_400}
 `

--- a/frontend/src/components/PollMain/PollMainDetail/PollMainDetail.tsx
+++ b/frontend/src/components/PollMain/PollMainDetail/PollMainDetail.tsx
@@ -25,26 +25,26 @@ function PollMainDetail({ isAnonymous, allowedPollCount, closedAt }: Props) {
   const theme = useTheme();
 
   return (
-    <FlexContainer flexDirection="column" gap="1.2rem">
+    <FlexContainer flexDirection="column" gap="1.6rem">
       <StyledCloseTime>
         {getFormattedClosedTime(closedAt)}
         까지
       </StyledCloseTime>
-      <FlexContainer gap="1.2rem">
+      <FlexContainer gap="1.6rem">
         <TextField
-          width="3.6rem"
+          width="5.2rem"
           borderRadius="20px"
           variant="outlined"
-          padding="0.4rem 0"
+          padding="0.8rem 0"
           colorScheme={theme.colors.PURPLE_100}
         >
           <StyledDetail>{isAnonymous ? '익명' : '기명'}</StyledDetail>
         </TextField>
         <TextField
-          width="7.6rem"
+          width="10.4rem"
           borderRadius="20px"
           variant="outlined"
-          padding="0.4rem 0"
+          padding="0.8rem 0"
           colorScheme={theme.colors.PURPLE_100}
         >
           <StyledDetail>
@@ -57,14 +57,14 @@ function PollMainDetail({ isAnonymous, allowedPollCount, closedAt }: Props) {
 }
 
 const StyledCloseTime = styled.p`
-  font-size: 0.8rem;
+  font-size: 1.4rem;
   align-self: end;
 `;
 
 const StyledDetail = styled.span(
   ({ theme }) => `
   color: ${theme.colors.PURPLE_100};
-  font-size: 0.8rem;
+  font-size: 1.2rem;
 `
 );
 

--- a/frontend/src/components/PollMain/PollMainHeader/PollMainHeader.tsx
+++ b/frontend/src/components/PollMain/PollMainHeader/PollMainHeader.tsx
@@ -18,11 +18,12 @@ function PollMainHeader() {
       <FlexContainer justifyContent="space-between">
         <StyledTitle>투표 목록</StyledTitle>
         <Button
-          width="12rem"
+          width="16rem"
           colorScheme={theme.colors.PURPLE_100}
           variant="filled"
           onClick={handleNavigate('create')}
-          fontSize="1.6rem"
+          fontSize="2rem"
+          padding="1.6rem 0"
         >
           투표 생성하기
         </Button>

--- a/frontend/src/components/PollMain/PollMainProgress/PollMainProgress.tsx
+++ b/frontend/src/components/PollMain/PollMainProgress/PollMainProgress.tsx
@@ -48,7 +48,7 @@ function PollMainProgress({ currentParticipants, groupCode }: Props) {
 }
 
 const StyledParticipantsStatus = styled.p`
-  font-size: 0.8rem;
+  font-size: 1.6rem;
 `;
 
 export default PollMainProgress;

--- a/frontend/src/components/PollMain/PollMainStatus/PollMainStatus.tsx
+++ b/frontend/src/components/PollMain/PollMainStatus/PollMainStatus.tsx
@@ -13,8 +13,8 @@ function PollMainStatus({ status }: Props) {
   return (
     <TextField
       variant="filled"
-      width="4rem"
-      padding="0.4rem 0"
+      width="7.2rem"
+      padding="0.8rem 0"
       borderRadius="5px"
       colorScheme={status === 'OPEN' ? theme.colors.PURPLE_100 : theme.colors.GRAY_400}
     >
@@ -26,6 +26,7 @@ function PollMainStatus({ status }: Props) {
 const StyledStatus = styled.span(
   ({ theme }) => `
   color: ${theme.colors.WHITE_100};
+  font-size: 1.2rem;
 `
 );
 

--- a/frontend/src/components/PollProgress/PollProgressDetail/PollProgressDetail.tsx
+++ b/frontend/src/components/PollProgress/PollProgressDetail/PollProgressDetail.tsx
@@ -23,7 +23,7 @@ function PollProgressDetail({ isAnonymous, allowedPollCount }: Props) {
         <StyledDetail>{isAnonymous ? '익명' : '기명'}</StyledDetail>
       </TextField>
       <TextField
-        width="9.2rem"
+        width="11.2rem"
         borderRadius="20px"
         padding="1.2rem 0"
         variant="outlined"
@@ -40,7 +40,7 @@ function PollProgressDetail({ isAnonymous, allowedPollCount }: Props) {
 const StyledDetail = styled.span(
   ({ theme }) => `
   color: ${theme.colors.PURPLE_100};
-  font-size: 0.8rem;
+  font-size: 1.2rem;
 `
 );
 

--- a/frontend/src/components/PollProgress/PollProgressForm/PollProgressForm.tsx
+++ b/frontend/src/components/PollProgress/PollProgressForm/PollProgressForm.tsx
@@ -139,7 +139,7 @@ function PollProgressForm() {
   }, [pollItems]);
 
   return (
-    <Box width="84.4rem" padding="6.4rem 4.8rem 5.4rem 4.8rem">
+    <Box width="84.4rem" padding="6.4rem 4.8rem">
       {poll ? (
         <form onSubmit={handleSubmit}>
           <MarginContainer margin="0 0 4rem 0">
@@ -152,7 +152,7 @@ function PollProgressForm() {
               allowedPollCount={poll.allowedPollCount}
             />
           </MarginContainer>
-          <MarginContainer margin="0 0 8.4rem 0">
+          <MarginContainer margin="0 0 23.6rem 0">
             <PollProgressItemGroup
               pollItems={pollItems}
               selectedPollItems={selectedPollItems}

--- a/frontend/src/components/PollProgress/PollProgressItemGroup/PollProgressItemGroup.tsx
+++ b/frontend/src/components/PollProgress/PollProgressItemGroup/PollProgressItemGroup.tsx
@@ -76,7 +76,7 @@ function PollProgressItemGroup({
               >
                 <Input
                   color={theme.colors.BLACK_100}
-                  fontSize="1.2rem"
+                  fontSize="1.6rem"
                   placeholder="선택한 이유는?"
                   value={selectedPollItem?.description}
                   onChange={onChangeText(id)}

--- a/frontend/src/components/PollResult/PollResultButtonGroup/PollResultButtonGroup.tsx
+++ b/frontend/src/components/PollResult/PollResultButtonGroup/PollResultButtonGroup.tsx
@@ -52,11 +52,11 @@ function PollResultButtonGroup({ pollCode, status, isHost, groupCode, pollItems 
     return (
       <>
         {status === 'OPEN' && (
-          <FlexContainer gap="2rem" justifyContent="center">
+          <FlexContainer gap="2rem" justifyContent="space-between">
             <Button
               type="button"
               variant="filled"
-              width="15.4rem"
+              width="22.8rem"
               padding="2rem 0"
               fontSize="2rem"
               colorScheme={theme.colors.GRAY_400}
@@ -67,7 +67,7 @@ function PollResultButtonGroup({ pollCode, status, isHost, groupCode, pollItems 
             <Button
               type="button"
               variant="filled"
-              width="15.4rem"
+              width="22.8rem"
               padding="2rem 0"
               fontSize="2rem"
               colorScheme={theme.colors.GRAY_400}
@@ -78,7 +78,7 @@ function PollResultButtonGroup({ pollCode, status, isHost, groupCode, pollItems 
             <Button
               type="button"
               variant="filled"
-              width="15.4rem"
+              width="22.8rem"
               padding="2rem 0"
               fontSize="2rem"
               colorScheme={theme.colors.PURPLE_100}
@@ -94,7 +94,7 @@ function PollResultButtonGroup({ pollCode, status, isHost, groupCode, pollItems 
             <Button
               type="button"
               variant="filled"
-              width="32.4rem"
+              width="22.8rem"
               padding="2rem 0"
               fontSize="2rem"
               colorScheme={theme.colors.GRAY_400}
@@ -115,7 +115,7 @@ function PollResultButtonGroup({ pollCode, status, isHost, groupCode, pollItems 
           <Button
             type="button"
             variant="filled"
-            width="15.4rem"
+            width="22.8rem"
             padding="2rem 0"
             fontSize="2rem"
             colorScheme={theme.colors.PURPLE_100}

--- a/frontend/src/components/PollResult/PollResultContainer/PollResultContainer.tsx
+++ b/frontend/src/components/PollResult/PollResultContainer/PollResultContainer.tsx
@@ -65,7 +65,7 @@ function PollResultContainer() {
   }, []);
 
   return (
-    <Box width="84.4rem" padding="2rem 4.8rem 5.6rem">
+    <Box width="84.4rem" padding="6.4rem 4.8rem">
       {poll ? (
         <>
           <FlexContainer justifyContent="end">
@@ -94,7 +94,7 @@ function PollResultContainer() {
               closedAt={poll.closedAt}
             />
           </MarginContainer>
-          <MarginContainer margin="0 0 4rem 0">
+          <MarginContainer margin="0 0 15.2rem 0">
             <FlexContainer flexDirection="column" gap="1.2rem">
               <PollResultItemGroup
                 status={poll.status}

--- a/frontend/src/components/PollResult/PollResultDetail/PollResultDetail.tsx
+++ b/frontend/src/components/PollResult/PollResultDetail/PollResultDetail.tsx
@@ -41,7 +41,7 @@ function PollResultDetail({ isAnonymous, allowedPollCount, closedAt }: Props) {
         <StyledDetail>{isAnonymous ? '익명' : '기명'}</StyledDetail>
       </TextField>
       <TextField
-        width="9.2rem"
+        width="11.2rem"
         borderRadius="20px"
         padding="1.2rem 0"
         variant="outlined"
@@ -70,7 +70,7 @@ const StyledCloseTime = styled.p`
 const StyledDetail = styled.span(
   ({ theme }) => `
   color: ${theme.colors.PURPLE_100};
-  font-size: 0.8rem;
+  font-size: 1.2rem;
 `
 );
 

--- a/frontend/src/components/PollResult/PollResultShareLink/PollResultShareLink.tsx
+++ b/frontend/src/components/PollResult/PollResultShareLink/PollResultShareLink.tsx
@@ -30,8 +30,8 @@ function PollResultShareLink({ groupCode, pollCode, status }: Props) {
 }
 
 const StyledLink = styled.img`
-  width: 2rem;
-  height: 2rem;
+  width: 2.4rem;
+  height: 2.4rem;
   cursor: pointer;
 `;
 

--- a/frontend/src/components/PollResult/PollResultStatus/PollResultStatus.tsx
+++ b/frontend/src/components/PollResult/PollResultStatus/PollResultStatus.tsx
@@ -13,7 +13,7 @@ function PollResultStatus({ status }: Props) {
   return (
     <TextField
       variant="filled"
-      width="6.4rem"
+      width="8rem"
       padding="1.6rem 0"
       borderRadius="1.2rem"
       colorScheme={status === 'OPEN' ? theme.colors.PURPLE_100 : theme.colors.GRAY_400}
@@ -26,7 +26,7 @@ function PollResultStatus({ status }: Props) {
 const StyledStatus = styled.span(
   ({ theme }) => `
   color: ${theme.colors.WHITE_100};
-  font-size:1.2rem;
+  font-size:1.6rem;
 `
 );
 

--- a/frontend/src/pages/AppointmentCreatePage/AppointmentCreatePage.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/AppointmentCreatePage.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import AppointmentCreateForm from '../../components/AppointmentCreate/AppointmentCreateForm/AppointmentCreateForm';
 import Calendar from '../../components/@common/Calendar/Calendar';
 import AppointmentCreateHeader from '../../components/AppointmentCreate/AppointmentCreateHeader/AppointmentCreateHeadert';
+import FlexContainer from '../../components/@common/FlexContainer/FlexContainer';
 
 function AppointmentCreatePage() {
   const [startDate, setStartDate] = useState(''); // 2022-08-20 과 같은 형식이 들어옴 -> new Date()로 감싸서 사용 가능
@@ -10,18 +11,22 @@ function AppointmentCreatePage() {
 
   return (
     <StyledContainer>
-      <StyledLeftContainer>
-        <AppointmentCreateHeader />
-        <Calendar
-          startDate={startDate}
-          endDate={endDate}
-          setStartDate={setStartDate}
-          setEndDate={setEndDate}
-        />
-      </StyledLeftContainer>
-      <StyledRightContainer>
-        <AppointmentCreateForm startDate={startDate} endDate={endDate} />
-      </StyledRightContainer>
+      <FlexContainer flexDirection='column' gap="2rem">
+        <AppointmentCreateHeader /> 
+        <FlexContainer gap="4rem">
+          <StyledLeftContainer>
+            <Calendar
+              startDate={startDate}
+              endDate={endDate}
+              setStartDate={setStartDate}
+              setEndDate={setEndDate}
+            />
+          </StyledLeftContainer>
+          <StyledRightContainer>
+            <AppointmentCreateForm startDate={startDate} endDate={endDate} />
+          </StyledRightContainer>
+        </FlexContainer>
+      </FlexContainer>
     </StyledContainer>
   );
 }

--- a/frontend/src/pages/AppointmentProgressPage/AppointmentProgressPage.tsx
+++ b/frontend/src/pages/AppointmentProgressPage/AppointmentProgressPage.tsx
@@ -10,9 +10,9 @@ import {
 } from '../../types/appointment';
 import Calendar from '../../components/@common/Calendar/Calendar';
 import AppointmentProgressHeader from '../../components/AppointmentProgress/AppointmentProgressHeader/AppointmentProgressHeader';
-import AppointmentProgressDetail from '../../components/AppointmentProgress/AppointmentProgressDetail/AppointmentProgressDetail';
 import AppointmentProgressTimePicker from '../../components/AppointmentProgress/AppointmentProgressTimePicker/AppointmentProgressTimePicker';
 import AppointmentProgressButtonGroup from '../../components/AppointmentProgress/AppointmentProgressButtonGroup/AppointmentProgressButtonGroup';
+import FlexContainer from '../../components/@common/FlexContainer/FlexContainer';
 
 // TODO: 중복됨 제거
 const getPlusOneDate = (date: string) => {
@@ -111,41 +111,38 @@ function AppointmentProgressPage() {
   // NOTE: 이렇게 Left,Right가 있을 때는 어떻게 추상화 레벨을 맞춰줄까?...
   return (
     <StyledContainer>
-      <StyledLeftContainer>
+      <FlexContainer flexDirection='column' gap="2rem">
         <AppointmentProgressHeader
-          title={appointment.title}
-          description={appointment.description}
+          appointment={appointment}
         />
-        <Calendar
-          version="select"
-          startDate={appointment.startDate}
-          endDate={
-            appointment.endTime === '12:00AM'
-              ? getMinusOneDate(appointment.endDate)
-              : appointment.endDate
-          }
-          selectedDate={selectedDate}
-          // TODO: setSelectedDate를 넘겨주는 것이 아니라 onClickDay 같이 해주는 게 어떨까? props를 받는 Calendar 컴포넌트에서는
-          // 위에서 어떤 함수가 내려오는 지 정확한 이름을 알 필요가 없다. 바깥에는 onClickDay 같이 소통할 수 있는 인터페이스만 제공해주면 될뿐
-          setSelectedDate={setSelectedDate}
-        />
-      </StyledLeftContainer>
-      <StyledRightContainer>
-        <AppointmentProgressDetail
-          durationHours={appointment.durationHours}
-          durationMinutes={appointment.durationMinutes}
-          startTime={appointment.startTime}
-          endTime={appointment.endTime}
-        />
-        <AppointmentProgressTimePicker
-          startTime={appointment.startTime}
-          endTime={appointment.endTime}
-          selectedDate={selectedDate}
-          onClickTime={handleAvailableTimes}
-          availableTimes={availableTimes}
-        />
-        <AppointmentProgressButtonGroup onClickProgress={handleProgressAppointment} />
-      </StyledRightContainer>
+        <FlexContainer gap="4rem">
+          <StyledLeftContainer>
+            <Calendar
+              version="select"
+              startDate={appointment.startDate}
+              endDate={
+                appointment.endTime === '12:00AM'
+                  ? getMinusOneDate(appointment.endDate)
+                  : appointment.endDate
+              }
+              selectedDate={selectedDate}
+              // TODO: setSelectedDate를 넘겨주는 것이 아니라 onClickDay 같이 해주는 게 어떨까? props를 받는 Calendar 컴포넌트에서는
+              // 위에서 어떤 함수가 내려오는 지 정확한 이름을 알 필요가 없다. 바깥에는 onClickDay 같이 소통할 수 있는 인터페이스만 제공해주면 될뿐
+              setSelectedDate={setSelectedDate}
+            />
+          </StyledLeftContainer>
+          <StyledRightContainer>
+            <AppointmentProgressTimePicker
+              startTime={appointment.startTime}
+              endTime={appointment.endTime}
+              selectedDate={selectedDate}
+              onClickTime={handleAvailableTimes}
+              availableTimes={availableTimes}
+            />
+            <AppointmentProgressButtonGroup onClickProgress={handleProgressAppointment} />
+          </StyledRightContainer>
+        </FlexContainer>
+      </FlexContainer>
     </StyledContainer>
   );
 }
@@ -153,9 +150,10 @@ function AppointmentProgressPage() {
 const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 18.4rem;
+  gap: 8rem;
 `;
 
 const StyledLeftContainer = styled.div`
@@ -168,7 +166,6 @@ const StyledLeftContainer = styled.div`
 const StyledRightContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 38.8rem;
   gap: 1.2rem;
   align-items: center;
 `;


### PR DESCRIPTION
## 상세 내용
- 데스크탑 (1920 * 1080)에 스타일이 깨지지 않도록 스타일을 수정한다. 
- 투표하기
    - [x] 투표 생성 페이지 등 input - placeholder 키우기, font-size 키우기 + detail 태그도 font-size도 같이 변경해보기
    - [x] 투표 결과 페이지 font 전체적으로 키우기, status 태그 키우기
    - [x] 버튼 크기를 일관적으로
- 약속잡기
    - 약속잡기 메인
        - [x] 투표 메인과 똑같이 만들기
    - 약속잡기 생성
        - [x] 레이아웃 변경
    - 약속잡기 진행
        - [x] gap 줄이기
        - [x] 오른쪽 크기 키우기
        - [x] 레이아웃 
    - 약속잡기 결과
        - [x] 폰트
        - [x] 상태 폰트 크기 키우기 

Close #374

