### PR TITLE
feat: 성능 측정 결과 슬랙 알림 기능 구현 

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
+    <springProperty name="SLACK_ERROR_URL" source="logging.slack.error-url"/>
+
     <property name="LOGS_ABSOLUTE_PATH" value="./logs"/>
     <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{36} - %msg%n"/>
     <property name="MAX_HISTORY" value="30"/>
+    <property name="PERFORMANCE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss} %-5level %msg%n"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
@@ -71,7 +74,6 @@
         </rollingPolicy>
     </appender>
 
-    <springProperty name="SLACK_ERROR_URL" source="logging.slack.error-url"/>
     <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
         <webhookUri>${SLACK_ERROR_URL}</webhookUri>
         <layout class="ch.qos.logback.classic.PatternLayout">
@@ -101,8 +103,22 @@
         </rollingPolicy>
         <encoder>
             <charset>utf8</charset>
-            <Pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %msg%n</Pattern>
+            <Pattern>${PERFORMANCE_LOG_PATTERN}</Pattern>
         </encoder>
+    </appender>
+
+    <appender name="PERFORMANCE_SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_ERROR_URL}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>${PERFORMANCE_LOG_PATTERN}</pattern>
+        </layout>
+        <username>MORAK-BOT</username>
+        <iconEmoji>:oncoming_police_car:</iconEmoji>
+        <colorCoding>true</colorCoding>
+    </appender>
+
+    <appender name="PERFORMANCE_ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="PERFORMANCE_SLACK"/>
     </appender>
 
     <root level="INFO">
@@ -120,6 +136,7 @@
 
     <logger name="PERFORMANCE">
         <appender-ref ref="PERFORMANCE"/>
+        <appender-ref ref="PERFORMANCE_ASYNC_SLACK"/>
     </logger>
 
 </configuration>

--- a/backend/src/test/java/com/morak/back/performance/support/PollDummySupport.java
+++ b/backend/src/test/java/com/morak/back/performance/support/PollDummySupport.java
@@ -79,7 +79,7 @@ public class PollDummySupport {
     public List<PollResult> makeDummyPollResult(Member member, int pollItemSize) {
         return LongStream.rangeClosed(1L, pollItemSize)
                 .mapToObj(pollItemIndex -> PollResult.builder()
-                        .pollItem(PollItem.builder().id(pollItemIndex).build())
+                        .pollItem(PollItem.builder().id(pollItemIndex).poll(Poll.builder().build()).build())
                         .member(member)
                         .description("더미 투표 선택 결과")
                         .build())


### PR DESCRIPTION
## 상세 내용

성능 측정 결과를 기존에는 로컬의 performance.log에만 기록하고 있었습니다. 
이것을 모두가 공유할 수 있도록 슬랙에 결과를 보내도록 구현했습니다. (원리는 기존의 ERROR 레벨의 로그를 슬랙 알림으로 쏴주는 것과 같음!)

추가적으로, PollResult 객체 생성시 생기던 오류 수정도 적용해놨습니다.

## 주의

- 현재 결과가 한줄 한줄 따로 알림이 가고 있기 때문에 #performance 채널에 대한 알림을 꺼두시는 것이 좋겠습니다. 
- PerformanceTest를 실행할 때, SLACK_ERROR_URL 환경변수를 설정해줘야합니다. 개발일지에 있습니다. 
- 알림을 보내고 싶지 않을 경우 SLACK_ERROR_URL 환경변수에 빈값을 넣어주세요!

#### 예시 이미지
<img width="1123" alt="image" src="https://user-images.githubusercontent.com/45311765/191431428-4128edbe-573a-48fc-b922-086ca246573b.png">


Close #398 
