### PR TITLE
feat(appointment): 약속잡기에서 공동 1등이 나왔을 경우 투표생성 페이지를 연동

### DIFF
--- a/frontend/src/api/appointment.ts
+++ b/frontend/src/api/appointment.ts
@@ -34,6 +34,12 @@ const deleteAppointment = (
   appointmentCode: AppointmentInterface['code']
 ) => axios.delete(`/${groupCode}/appointments/${appointmentCode}`);
 
+const getAppointmentStatus = (
+  groupCode: GroupInterface['code'],
+  appointmentCode: AppointmentInterface['code']
+) => axios.get(`/${groupCode}/appointments/${appointmentCode}/status`);
+
+
 export {
   getAppointments,
   getAppointment,
@@ -41,5 +47,6 @@ export {
   progressAppointment,
   getAppointmentRecommendation,
   closeAppointment,
-  deleteAppointment
+  deleteAppointment,
+  getAppointmentStatus
 };

--- a/frontend/src/components/AppointmentResult/AppointmentResultButtonGroup/AppointmentResultButtonGroup.tsx
+++ b/frontend/src/components/AppointmentResult/AppointmentResultButtonGroup/AppointmentResultButtonGroup.tsx
@@ -6,7 +6,7 @@ import { AxiosError } from 'axios';
 import FlexContainer from '../../@common/FlexContainer/FlexContainer';
 import { GroupInterface } from '../../../types/group';
 import { AppointmentInterface, getAppointmentResponse } from '../../../types/appointment';
-import { closeAppointment, deleteAppointment } from '../../../api/appointment';
+import { closeAppointment, deleteAppointment, getAppointmentRecommendation, getAppointmentStatus } from '../../../api/appointment';
 import Button from '../../@common/Button/Button';
 
 interface Props {
@@ -34,6 +34,19 @@ function AppointmentResultButtonGroup({ groupCode, appointmentCode, isClosed, is
     }
   };
 
+  const handleCreateNewPoll = async () => {
+    try {
+      const response = await getAppointmentStatus(groupCode, appointmentCode)
+      if (response.data.status === "CLOSED") {
+          const res = await getAppointmentRecommendation(groupCode, appointmentCode)
+          console.log(res)
+      }
+
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
   const handleDeleteAppointment = async () => {
     try {
       if (window.confirm('약속잡기를 삭제하시겠습니까?')) {
@@ -52,7 +65,7 @@ function AppointmentResultButtonGroup({ groupCode, appointmentCode, isClosed, is
     }
   };
 
-  return (
+return (
     <FlexContainer gap="4rem" justifyContent="center">
       {isHost && (
         <>
@@ -77,6 +90,15 @@ function AppointmentResultButtonGroup({ groupCode, appointmentCode, isClosed, is
             onClick={handleDeleteAppointment}
           >
             삭제
+          </Button>
+          <Button
+            variant="filled"
+            colorScheme={theme.colors.YELLOW_100} 
+            padding="2rem 2rem"
+            fontSize="3.2rem"
+            onClick={handleCreateNewPoll}
+          >
+            애매해? 투표 ㄱ
           </Button>
         </>
       )}

--- a/frontend/src/components/AppointmentResult/AppointmentResultButtonGroup/AppointmentResultButtonGroup.tsx
+++ b/frontend/src/components/AppointmentResult/AppointmentResultButtonGroup/AppointmentResultButtonGroup.tsx
@@ -37,8 +37,8 @@ function AppointmentResultButtonGroup({ groupCode, appointmentCode, isClosed, is
     }
   };
 
-  const firstRankAppointmentRecommendation = appointmentRecommendation
-  .filter((appointment) => appointment.rank === 1)
+  const firstRankAppointmentRecommendations = appointmentRecommendation
+  .filter(({rank}) => rank === 1)
   .map(({recommendStartDateTime, recommendEndDateTime}) => {
     return `${getFormattedDateTime(recommendStartDateTime)}~${getFormattedDateTime(recommendEndDateTime)}`;
   });
@@ -48,7 +48,7 @@ function AppointmentResultButtonGroup({ groupCode, appointmentCode, isClosed, is
         navigate(`/groups/${groupCode}/poll/create`, {
           state: {
             title,
-            firstRankAppointmentRecommendation
+            firstRankAppointmentRecommendations
           }
         });
     } catch (err) {
@@ -100,11 +100,11 @@ return (
           >
             삭제
           </Button>
-          {(isClosed && firstRankAppointmentRecommendation.length > 1) && (
+          {(isClosed && firstRankAppointmentRecommendations.length > 1) && (
             <Button
               variant="filled"
               colorScheme={theme.colors.YELLOW_100} 
-              padding="2rem 2rem"
+              padding="2rem"
               fontSize="3.2rem"
               onClick={handleCreateNewPoll}
             >

--- a/frontend/src/components/AppointmentResult/AppointmentResultRanking/AppointmentResultRanking.tsx
+++ b/frontend/src/components/AppointmentResult/AppointmentResultRanking/AppointmentResultRanking.tsx
@@ -6,26 +6,7 @@ import { AppointmentRecommendationInterface } from '../../../types/appointment';
 import { GroupInterface, MemberInterface } from '../../../types/group';
 import { getGroupMembers } from '../../../api/group';
 import FlexContainer from '../../@common/FlexContainer/FlexContainer';
-
-const getDateTime = (
-  recommendationDateTime: AppointmentRecommendationInterface[
-    | 'recommendStartDateTime'
-    | 'recommendEndDateTime']
-) => {
-  // TODO: 리팩토링
-  const period = recommendationDateTime.slice(-2);
-  const dateTime = new Date(recommendationDateTime.slice(0, -2));
-  const week = ['일', '월', '화', '수', '목', '금', '토'];
-
-  const year = dateTime.getFullYear();
-  const month = dateTime.getMonth() + 1;
-  const date = dateTime.getDate();
-  const day = week[dateTime.getDay()];
-  const hour = dateTime.getHours().toString().padStart(2, '0');
-  const minutes = dateTime.getMinutes().toString().padStart(2, '0');
-
-  return ` ${year}.${month}.${date}(${day}) ${hour}:${minutes}${period} `;
-};
+import { getFormattedDateTime } from '../../../utils/date';
 
 interface Props {
   groupCode: GroupInterface['code'];
@@ -86,7 +67,7 @@ function AppointmentResultRanking({
                 <StyledResultText>{rank}</StyledResultText>
               )}
               <StyledResultText>
-                {getDateTime(recommendStartDateTime)}<br/>~{getDateTime(recommendEndDateTime)}
+                {getFormattedDateTime(recommendStartDateTime)}<br/>~{getFormattedDateTime(recommendEndDateTime)}
               </StyledResultText>
               <StyledResultText>
                 {availableMembers.length}/{totalParticipants}명 가능

--- a/frontend/src/components/PollCreate/PollCreateForm/PollCreateForm.tsx
+++ b/frontend/src/components/PollCreate/PollCreateForm/PollCreateForm.tsx
@@ -1,7 +1,7 @@
 import { useState, FormEvent, ChangeEvent } from 'react';
 
 // TODO: 자동정렬 설정
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import Box from '../../@common/Box/Box';
 import Divider from '../../@common/Divider/Divider';
@@ -17,15 +17,25 @@ import { createPoll } from '../../../api/poll';
 import { createPollData, PollInterface } from '../../../types/poll';
 import { GroupInterface } from '../../../types/group';
 import useInput from '../../../hooks/useInput';
+import { AppointmentInterface } from '../../../types/appointment';
+
+interface RouteState {
+  state : {
+    title: AppointmentInterface['title'];
+    firstRankAppointmentRecommendation: Array<string>;
+  }
+}
 
 function PollCreateForm() {
+  const location = useLocation() as RouteState;
   const navigate = useNavigate();
   const { groupCode } = useParams() as { groupCode: GroupInterface['code'] };
 
-  const [title, setTitle] = useState('');
+  const [title, setTitle] = useState(location.state? location.state.title: '');
   const [isAnonymous, setIsAnonymous] = useState(false);
   const [isAllowedMultiplePollCount, setIsAllowedMultiplePollCount] = useState(false);
-  const [pollItems, setPollItems] = useState(['', '']);
+  const [pollItems, setPollItems] = useState(location.state? location.state.firstRankAppointmentRecommendation : ['', '']);
+  
   const [closingDate, handleCloseDate] = useInput('');
   const [closingTime, handleCloseTime] = useInput('');
 

--- a/frontend/src/components/PollCreate/PollCreateForm/PollCreateForm.tsx
+++ b/frontend/src/components/PollCreate/PollCreateForm/PollCreateForm.tsx
@@ -1,7 +1,7 @@
 import { useState, FormEvent, ChangeEvent } from 'react';
 
 // TODO: 자동정렬 설정
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams, Location } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import Box from '../../@common/Box/Box';
 import Divider from '../../@common/Divider/Divider';
@@ -19,22 +19,21 @@ import { GroupInterface } from '../../../types/group';
 import useInput from '../../../hooks/useInput';
 import { AppointmentInterface } from '../../../types/appointment';
 
-interface RouteState {
+interface LocationWithState extends Location {
   state : {
     title: AppointmentInterface['title'];
-    firstRankAppointmentRecommendation: Array<string>;
+    firstRankAppointmentRecommendations: Array<string>;
   }
 }
 
 function PollCreateForm() {
-  const location = useLocation() as RouteState;
+  const location = useLocation() as LocationWithState;
   const navigate = useNavigate();
   const { groupCode } = useParams() as { groupCode: GroupInterface['code'] };
-
-  const [title, setTitle] = useState(location.state? location.state.title: '');
+  const [title, setTitle] = useState(location.state?.title ?? '');
   const [isAnonymous, setIsAnonymous] = useState(false);
   const [isAllowedMultiplePollCount, setIsAllowedMultiplePollCount] = useState(false);
-  const [pollItems, setPollItems] = useState(location.state? location.state.firstRankAppointmentRecommendation : ['', '']);
+  const [pollItems, setPollItems] = useState(location.state?.firstRankAppointmentRecommendations ?? ['', '']);
   
   const [closingDate, handleCloseDate] = useInput('');
   const [closingTime, handleCloseTime] = useInput('');

--- a/frontend/src/components/PollCreate/PollCreateFormInputGroup/PollCreateFormInputGroup.tsx
+++ b/frontend/src/components/PollCreate/PollCreateFormInputGroup/PollCreateFormInputGroup.tsx
@@ -54,8 +54,6 @@ function PollCreateFormInputGroup({ pollItems, setPollItems }: Props) {
     setPollItems(newPollItems);
   };
 
-  console.log(pollItems);
-
   return (
     <FlexContainer flexDirection="column" gap="1.2rem">
       {pollItems.map((pollItem, idx) => (

--- a/frontend/src/pages/AppointmentResultPage/AppointmentResultPage.tsx
+++ b/frontend/src/pages/AppointmentResultPage/AppointmentResultPage.tsx
@@ -82,8 +82,10 @@ function AppointmentResultPage() {
         </FlexContainer>
         <AppointmentResultButtonGroup
           groupCode={groupCode}
+          appointmentRecommendation={appointmentRecommendation}
           appointmentCode={appointmentCode}
           isClosed={appointment.isClosed}
+          title={appointment.title}
           isHost={appointment.isHost}
         />
       </FlexContainer>

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,0 +1,17 @@
+const getFormattedDateTime = (dateTimeInput: string) => {
+  // TODO: 리팩토링
+  const period = dateTimeInput.slice(-2);
+  const dateTime = new Date(dateTimeInput.slice(0, -2));
+  const week = ['일', '월', '화', '수', '목', '금', '토'];
+
+  const year = dateTime.getFullYear();
+  const month = dateTime.getMonth() + 1;
+  const date = dateTime.getDate();
+  const day = week[dateTime.getDay()];
+  const hour = dateTime.getHours().toString().padStart(2, '0');
+  const minutes = dateTime.getMinutes().toString().padStart(2, '0');
+
+  return `${year}.${month}.${date}(${day}) ${hour}:${minutes}${period}`;
+};
+
+export { getFormattedDateTime };


### PR DESCRIPTION
## 상세 내용
- `공동 1등에 대한 재투표 만들기` 버튼이 나오는 경우는, **호스트이면서 + 약속잡기를 '마감'했을 때 + 공동 1등이 존재할 때**입니다. 
- 이 경우, status를 불러오는 api를 호출하는 것은 불필요해서 제외했습니다. handleCreateNewPoll 메서드에서 약속결과 진행중 페이지에서도 버튼을 넣어줬었던 코드는 아래와같았으나, 마감 페이지에서만 버튼을 넣어주고있는 현재는 `getAppointmentStatus` api를 호출하는 로직은 불필요하게 되어서 제외해주었습니다. 

```javascript
  const handleCreateNewPoll = async () => {
    try {
      const response = await getAppointmentStatus(groupCode, appointmentCode)
      if (response.data.status === "CLOSED") {
        navigate(`/groups/${groupCode}/poll/create`, {
          state: {
            title,
            firstRankAppointmentRecommendation
          }
        });
        return;
      }
      alert('마감이 되지 않은 약속잡기입니다. 마감 후 동일한 등수에 대해 재투표를 할 수 있습니다.');
    } catch (err) {
      console.log(err);
    }
  }
```
- 백엔드와 논의 결과, 약속잡기  진행중 페이지에서도 투표로 전환하기 기능이 서비스에 존재함을 사용자들에게 인지시켜주기 위해  마감 전 약속결과 진행중 페이지에서도 `공동 1등에 대한 재투표 만들기` 버튼이 존재해야된다고 결론을 내렸습니다. 
- 공동 1등인 경우 투표로 전환하기 기능이 있는지 알지 못하는 사용자는, 평생 마감 페이지에 공동 1등에 대한 재투표 버튼이 있는지 상상도 못할 수 있습니다. 😓 
왜냐면 보통 사용자가 '마감' 버튼을 직접 누르는 경우는 거의 없고, 마감 시간이 되면 자동으로 마감 되는 경우가 대다수니까요~
따라서 마감 페이지 이전인 약속결과 진행중 페이지에서도 버튼(꼭 버튼이 아니더라도 이 기능이 있음을 알려주는 것)이 필요하다고 논의를 했습니다. 
이부분은 앨버와 이야기도 해봐야될 것 같아서, 구현하지 않았습니다. 
또한 약속결과 진행중 페이지까지 버튼을 구현하는 것은 데모데이때까지 구현이 힘들 수 있을 것 같다고 판단 되어(시간이 꽤 걸릴 것 같다고 생각한 이유는 내일 알려드리겠습니다~) 일단 이번 데모데이에서는 현재 pr 코드 내용인 마감 페이지에서만 보여주는 것으로( **호스트이면서 + 약속잡기를 마감했을 때 + 공동 1등이 존재할 때** )백엔드와 합의 했습니다. 하하😅

일단 약속결과 진행중 페이지에서 버튼을 넣어줄 시 status 불러오는 api 가 필요할 수 있기 때문에 api 불러주는 함수를 삭제하지 않았습니다. 

## 구현 화면 
### 마감 화면 
<img width="972" alt="스크린샷 2022-09-21 오후 10 00 36" src="https://user-images.githubusercontent.com/52344833/191510488-ac0d1765-064f-445f-a252-d28c246b642c.png">

### 버튼 누르면 투표 생성 페이지로 이동 
<img width="704" alt="스크린샷 2022-09-21 오후 10 01 03" src="https://user-images.githubusercontent.com/52344833/191510588-c45bc688-bc53-432c-b5c5-ffd12d105155.png">


Close #394  
