### PR TITLE
fix(appointment): 약속잡기 마감시간이 설정되지 않는 문제 해결

### DIFF
--- a/frontend/src/components/AppointmentCreate/AppointmentCreateFormCloseTimeInput/AppointmentCreateFormCloseTimeInput.tsx
+++ b/frontend/src/components/AppointmentCreate/AppointmentCreateFormCloseTimeInput/AppointmentCreateFormCloseTimeInput.tsx
@@ -61,6 +61,6 @@ export default memo(
   AppointmentCreateFormCloseTimeInput,
   (prev, next) =>
     prev.closeTime === next.closeTime &&
-    prev.closeDate === next.closeTime &&
+    prev.closeDate === next.closeDate &&
     prev.maxCloseDate === next.maxCloseDate
 );


### PR DESCRIPTION
## 상세 내용
약속잡기 마감시간이 설정되지 않는 문제 해결하였습니다.

컴포넌트에 memo를 적용해서 메모이제이션을 적용해주었는데, 이에 대한 기준에 변수명이 잘못 들어가있었습니다..
