### PR TITLE
feat: 본인 이름 변경 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -19,6 +19,20 @@ include::{snippets}/auth/signin/http-request.adoc[]
 .HTTP RESPONSE
 include::{snippets}/auth/signin/http-response.adoc[]
 
+=== 본인 조회
+
+.HTTP REQUEST
+include::{snippets}/auth/get-me/http-request.adoc[]
+.HTTP RESPONSE
+include::{snippets}/auth/get-me/http-response.adoc[]
+
+=== 본인 이름 변경
+
+.HTTP REQUEST
+include::{snippets}/auth/change-name/http-request.adoc[]
+.HTTP RESPONSE
+include::{snippets}/auth/change-name/http-response.adoc[]
+
 === 에러 코드
 
 [cols="1,3",options=header]

--- a/backend/src/main/java/com/morak/back/auth/application/OAuthService.java
+++ b/backend/src/main/java/com/morak/back/auth/application/OAuthService.java
@@ -56,9 +56,9 @@ public class OAuthService {
                 .orElseGet(() -> memberRepository.save(memberResponse.toMember()));
     }
 
-    public MemberResponse findMember(Long id) {
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, id));
+    public MemberResponse findMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, memberId));
         return MemberResponse.from(member);
     }
 
@@ -67,6 +67,7 @@ public class OAuthService {
                 .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, memberId));
 
         member.changeName(request.getName());
+        memberRepository.flush();
     }
 }
 

--- a/backend/src/main/java/com/morak/back/auth/application/OAuthService.java
+++ b/backend/src/main/java/com/morak/back/auth/application/OAuthService.java
@@ -6,6 +6,7 @@ import com.morak.back.auth.domain.Member;
 import com.morak.back.auth.domain.MemberRepository;
 import com.morak.back.auth.exception.AuthenticationException;
 import com.morak.back.auth.exception.MemberNotFoundException;
+import com.morak.back.auth.ui.dto.ChangeNameRequest;
 import com.morak.back.auth.ui.dto.MemberResponse;
 import com.morak.back.auth.ui.dto.SigninRequest;
 import com.morak.back.auth.ui.dto.SigninResponse;
@@ -59,6 +60,13 @@ public class OAuthService {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, id));
         return MemberResponse.from(member);
+    }
+
+    public void changeName(Long memberId, ChangeNameRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, memberId));
+
+        member.changeName(request.getName());
     }
 }
 

--- a/backend/src/main/java/com/morak/back/auth/domain/Member.java
+++ b/backend/src/main/java/com/morak/back/auth/domain/Member.java
@@ -52,6 +52,10 @@ public class Member extends BaseEntity {
         return ANONYMOUS_MEMBER;
     }
 
+    public void changeName(String name) {
+        this.name = name;
+    }
+
     @Override
     @Generated
     public boolean equals(Object o) {

--- a/backend/src/main/java/com/morak/back/auth/domain/MemberRepository.java
+++ b/backend/src/main/java/com/morak/back/auth/domain/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends Repository<Member, Long> {
     Member save(Member member);
 
     Optional<Member> findById(Long memberId);
+
+    void flush();
 }

--- a/backend/src/main/java/com/morak/back/auth/ui/OAuthController.java
+++ b/backend/src/main/java/com/morak/back/auth/ui/OAuthController.java
@@ -2,12 +2,15 @@ package com.morak.back.auth.ui;
 
 import com.morak.back.auth.application.OAuthService;
 import com.morak.back.auth.support.Auth;
+import com.morak.back.auth.ui.dto.ChangeNameRequest;
 import com.morak.back.auth.ui.dto.MemberResponse;
 import com.morak.back.auth.ui.dto.SigninRequest;
 import com.morak.back.auth.ui.dto.SigninResponse;
+import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,7 +32,13 @@ public class OAuthController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<MemberResponse> findMe(@Auth Long id) {
-        return ResponseEntity.ok(oAuthService.findMember(id));
+    public ResponseEntity<MemberResponse> findMe(@Auth Long memberId) {
+        return ResponseEntity.ok(oAuthService.findMember(memberId));
+    }
+
+    @PatchMapping("/me/name")
+    public ResponseEntity<Void> changeName(@Auth Long memberId, @Valid @RequestBody ChangeNameRequest request) {
+        oAuthService.changeName(memberId, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/morak/back/auth/ui/dto/ChangeNameRequest.java
+++ b/backend/src/main/java/com/morak/back/auth/ui/dto/ChangeNameRequest.java
@@ -1,0 +1,15 @@
+package com.morak.back.auth.ui.dto;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChangeNameRequest {
+
+    @NotBlank(message = "변경하려는 이름은 blank일 수 없습니다.")
+    private String name;
+}

--- a/backend/src/test/java/com/morak/back/SimpleRestAssured.java
+++ b/backend/src/test/java/com/morak/back/SimpleRestAssured.java
@@ -1,8 +1,5 @@
 package com.morak.back;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.morak.back.core.exception.CustomErrorCode;
 import com.morak.back.core.ui.dto.ExceptionResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -69,6 +66,14 @@ public class SimpleRestAssured {
     public static ExtractableResponse<Response> patch(String path, Map<String, String> header) {
         return thenExtract(given()
                 .headers(header)
+                .when().patch(path));
+    }
+
+    public static ExtractableResponse<Response> patch(String path, Map<String, String> header, Object request) {
+        return thenExtract(given()
+                .headers(header)
+                .body(request)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().patch(path));
     }
 

--- a/backend/src/test/java/com/morak/back/auth/application/OAuthServiceTest.java
+++ b/backend/src/test/java/com/morak/back/auth/application/OAuthServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.morak.back.auth.application.dto.OAuthMemberInfoResponse;
 import com.morak.back.auth.domain.Member;
 import com.morak.back.auth.domain.MemberRepository;
+import com.morak.back.auth.ui.dto.ChangeNameRequest;
 import com.morak.back.auth.ui.dto.MemberResponse;
 import com.morak.back.auth.ui.dto.SigninRequest;
 import com.morak.back.auth.ui.dto.SigninResponse;
@@ -71,5 +72,20 @@ class OAuthServiceTest {
 
         // then
         assertThat(savedMember.getId()).isEqualTo(response.getId());
+    }
+
+    @Test
+    void 본인의_이름을_변경한다() {
+        // given
+        Member savedMember = memberRepository.save(oAuthClient.getMemberInfo("ignored").toMember());
+
+        ChangeNameRequest request = new ChangeNameRequest("변경하려는 이름");
+
+        // when
+        oAuthService.changeName(savedMember.getId(), request);
+
+        // then
+        MemberResponse foundMember = oAuthService.findMember(savedMember.getId());
+        assertThat(foundMember.getName()).isEqualTo("변경하려는 이름");
     }
 }

--- a/backend/src/test/java/com/morak/back/auth/domain/MemberTest.java
+++ b/backend/src/test/java/com/morak/back/auth/domain/MemberTest.java
@@ -32,4 +32,20 @@ class MemberTest {
         // then
         assertThat(anonymous.getId()).isEqualTo(0L);
     }
+
+    @Test
+    void 멤버의_이름을_변경한다() {
+        // given
+        Member member = Member.builder()
+                .name("RIANAEH")
+                .oauthId("oauth-id")
+                .profileUrl("http://profile_url.com")
+                .build();
+
+        // when
+        member.changeName("엘리");
+
+        // then
+        assertThat(member.getName()).isEqualTo("엘리");
+    }
 }

--- a/backend/src/test/java/com/morak/back/auth/ui/OAuthControllerTest.java
+++ b/backend/src/test/java/com/morak/back/auth/ui/OAuthControllerTest.java
@@ -5,12 +5,15 @@ import static com.morak.back.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.morak.back.auth.application.OAuthService;
+import com.morak.back.auth.ui.dto.ChangeNameRequest;
 import com.morak.back.auth.ui.dto.MemberResponse;
 import com.morak.back.auth.ui.dto.SigninRequest;
 import com.morak.back.auth.ui.dto.SigninResponse;
@@ -63,7 +66,30 @@ class OAuthControllerTest extends ControllerTest {
         // then
         response.andExpect(status().isOk())
                 .andDo(document(
-                        "auth/me",
+                        "auth/get-me",
+                        getDocumentRequest(),
+                        getDocumentResponse()
+                ));
+    }
+
+    @Test
+    void 본인_이름을_변경한다() throws Exception {
+        // given
+        ChangeNameRequest request = new ChangeNameRequest("변경하려는 이름");
+
+        doNothing().when(oAuthService).changeName(anyLong(), any(ChangeNameRequest.class));
+
+        // when
+        ResultActions response = mockMvc.perform(patch("/api/auth/me/name")
+                .header("Authorization", "Bearer aaaaaa.bbbbbb.ccccccc")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        response.andExpect(status().isOk())
+                .andDo(document(
+                        "auth/change-name",
                         getDocumentRequest(),
                         getDocumentResponse()
                 ));


### PR DESCRIPTION
## 상세 내용
본인 이름을 변경할 수 있는 API를 구현했어요. -> ` PATCH /api/auth/me/name`

기존에 본인을 조회할 수 있는 API가 있었는데 API 명세에는 없더라구요. 이 부분 수정했습니다!

Close #420 

<img width="986" alt="image" src="https://user-images.githubusercontent.com/45311765/193451362-530f9aed-1c27-4aa4-bd4e-9f9a4442490a.png">

<img width="983" alt="image" src="https://user-images.githubusercontent.com/45311765/193451380-bf9282e8-598d-422e-ab78-6eee02afc2de.png">
