### PR TITLE
feat: 랜딩페이지 모바일 사이즈 대응 

### DIFF
--- a/frontend/src/pages/LandingPage/components/LandingFeatureIntroductionSection/LandingFeatureIntroductionSection.styles.tsx
+++ b/frontend/src/pages/LandingPage/components/LandingFeatureIntroductionSection/LandingFeatureIntroductionSection.styles.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-const StyledFeatureIntroductionSection = styled.section`
+const StyledContainer = styled.section`
   position: relative;
   display: flex;
   justify-content: center;
@@ -17,7 +17,7 @@ const StyledIntroductionTitleContainer = styled.div`
 const StyledTitle = styled.h1(
   ({ theme }) => `
   font-size: 4rem;
-  text-align: left;
+  text-align: center;
   color: ${theme.colors.BLACK_100};
   margin-bottom: 1.2rem;
   position: relative;
@@ -37,8 +37,10 @@ const StyledSubTitle = styled.div(
 `
 );
 
-const StyledFeatureContainer = styled.div`
+const StyledFeaturesContainer = styled.div`
   display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
   gap: 4rem;
 `;
 
@@ -90,8 +92,8 @@ const StyledUndefinedImage = styled.img`
 export {
   StyledAppointmentImage,
   StyledFeatureCircle,
-  StyledFeatureContainer,
-  StyledFeatureIntroductionSection,
+  StyledFeaturesContainer,
+  StyledContainer,
   StyledFeatureName,
   StyledGlitterImage,
   StyledUndefinedImage,

--- a/frontend/src/pages/LandingPage/components/LandingFeatureIntroductionSection/LandingFeatureIntroductionSection.tsx
+++ b/frontend/src/pages/LandingPage/components/LandingFeatureIntroductionSection/LandingFeatureIntroductionSection.tsx
@@ -2,8 +2,8 @@ import { HTMLAttributes } from 'react';
 import {
   StyledAppointmentImage,
   StyledFeatureCircle,
-  StyledFeatureContainer,
-  StyledFeatureIntroductionSection,
+  StyledFeaturesContainer,
+  StyledContainer,
   StyledFeatureName,
   StyledGlitterImage,
   StyledUndefinedImage,
@@ -25,7 +25,7 @@ interface Props extends HTMLAttributes<HTMLElement> {}
 
 function LandingFeatureIntroductionSection({ id }: Props) {
   return (
-    <StyledFeatureIntroductionSection id={id}>
+    <StyledContainer id={id}>
       <LandingNavbar />
 
       <StyledIntroductionTitleContainer>
@@ -33,7 +33,7 @@ function LandingFeatureIntroductionSection({ id }: Props) {
         <StyledSubTitle>모락이 모임을 더 편하고, 즐겁게 할 수 있도록 도와줄게요</StyledSubTitle>
       </StyledIntroductionTitleContainer>
 
-      <StyledFeatureContainer>
+      <StyledFeaturesContainer>
         <div>
           <StyledFeatureCircle>
             <StyledPollImage src={Poll} alt="poll" />
@@ -56,15 +56,8 @@ function LandingFeatureIntroductionSection({ id }: Props) {
           </StyledFeatureCircle>
           <StyledFeatureName>coming soon!</StyledFeatureName>
         </div>
-
-        <div>
-          <StyledFeatureCircle>
-            <StyledUndefinedImage src={Undefined} alt="undefined" />
-          </StyledFeatureCircle>
-          <StyledFeatureName>coming soon!</StyledFeatureName>
-        </div>
-      </StyledFeatureContainer>
-    </StyledFeatureIntroductionSection>
+      </StyledFeaturesContainer>
+    </StyledContainer>
   );
 }
 

--- a/frontend/src/pages/LandingPage/components/LandingMainSection/LandingMainSection.styles.tsx
+++ b/frontend/src/pages/LandingPage/components/LandingMainSection/LandingMainSection.styles.tsx
@@ -39,8 +39,7 @@ const StyledLogo = styled.img`
   left: 4rem;
 `;
 
-// TODO: 왜 background-image로 했을까~ 일관성 ㅠㅠ
-const StyledMainSection = styled.section`
+const StyledContainer = styled.section`
   height: 100vh;
   display: flex;
   justify-content: center;
@@ -67,7 +66,7 @@ const StyledSubTitle = styled.div(
 
 const StyledTitle = styled.h1(
   ({ theme }) => `
-  font-size: 10.4rem;
+  font-size: 9.6rem;
   font-weight: 700;
   text-align: center;
   position: relative;
@@ -80,7 +79,7 @@ const StyledTitle = styled.h1(
 const StyledSmileImage = styled.img`
   position: absolute;
   bottom: 0;
-  left: -6.8rem;
+  left: -4.8rem;
   top: 7.6rem;
   width: 10rem;
 `;
@@ -115,13 +114,14 @@ const StyledBlobImage = styled.img`
   height: 17.4rem;
 `;
 
-const StyledGuideText = styled.span(
+const StyledAnchor = styled.a(
   ({ theme }) => `
-  position: absolute; 
-  top: 7.2rem; 
-  left: 4.2rem; 
-  font-size: 2.4rem; 
+  position: absolute;
+  top: 7.2rem;
+  left: 4.2rem;
+  text-decoration: none;
   color: ${theme.colors.BLACK_100};
+  font-size: 2.4rem;
 `
 );
 
@@ -130,15 +130,15 @@ export {
   StyledBlobImage,
   StyledGithubLogo,
   StyledGlitterImage,
-  StyledGuideText,
   StyledLineImage,
   StyledLink,
   StyledLoginContainer,
   StyledLoginText,
   StyledLogo,
-  StyledMainSection,
+  StyledContainer,
   StyledNextSectionGuideContainer,
   StyledSmileImage,
   StyledSubTitle,
-  StyledTitle
+  StyledTitle,
+  StyledAnchor
 };

--- a/frontend/src/pages/LandingPage/components/LandingMainSection/LandingMainSection.tsx
+++ b/frontend/src/pages/LandingPage/components/LandingMainSection/LandingMainSection.tsx
@@ -4,17 +4,17 @@ import {
   StyledBlobImage,
   StyledGithubLogo,
   StyledGlitterImage,
-  StyledGuideText,
   StyledLineImage,
   StyledLink,
   StyledLoginContainer,
   StyledLoginText,
   StyledLogo,
-  StyledMainSection,
+  StyledContainer,
   StyledNextSectionGuideContainer,
   StyledSmileImage,
   StyledSubTitle,
-  StyledTitle
+  StyledTitle,
+  StyledAnchor
 } from './LandingMainSection.styles';
 
 import Logo from '../../../../assets/logo.svg';
@@ -30,7 +30,7 @@ interface Props extends HTMLAttributes<HTMLElement> {}
 
 function LandingMainSection({ id }: Props) {
   return (
-    <StyledMainSection id={id}>
+    <StyledContainer id={id}>
       <LandingNavbar />
       <StyledLogo src={Logo} alt="logo" />
 
@@ -56,10 +56,10 @@ function LandingMainSection({ id }: Props) {
       <StyledNextSectionGuideContainer>
         <StyledBlobContainer>
           <StyledBlobImage src={Blob} alt="blob" />
-          <StyledGuideText>모락 소개</StyledGuideText>
+          <StyledAnchor href="#service-introduction-section">모락 소개</StyledAnchor>
         </StyledBlobContainer>
       </StyledNextSectionGuideContainer>
-    </StyledMainSection>
+    </StyledContainer>
   );
 }
 

--- a/frontend/src/pages/LandingPage/components/LandingNavbar/LandingNavbar.styles.tsx
+++ b/frontend/src/pages/LandingPage/components/LandingNavbar/LandingNavbar.styles.tsx
@@ -9,6 +9,10 @@ const StyledNavbar = styled.nav`
   gap: 4rem;
   font-size: 2rem;
   cursor: pointer;
+
+  @media (max-width: 700px) {
+    display: none;
+  }
 `;
 
 const StyledMenu = styled.a(

--- a/frontend/src/pages/LandingPage/components/LandingNavbar/LandingNavbar.styles.tsx
+++ b/frontend/src/pages/LandingPage/components/LandingNavbar/LandingNavbar.styles.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import responsive from '../../../../utils/responsive';
 
 const StyledNavbar = styled.nav`
   position: absolute;
@@ -10,9 +11,9 @@ const StyledNavbar = styled.nav`
   font-size: 2rem;
   cursor: pointer;
 
-  @media (max-width: 700px) {
+  ${responsive.mobile(`
     display: none;
-  }
+  `)}
 `;
 
 const StyledMenu = styled.a(

--- a/frontend/src/pages/LandingPage/components/LandingServiceIntroductionSection/LandingServiceIntroductionSection.styles.tsx
+++ b/frontend/src/pages/LandingPage/components/LandingServiceIntroductionSection/LandingServiceIntroductionSection.styles.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-const StyledServiceIntroductionSection = styled.section`
+const StyledContainer = styled.section`
   height: 100vh;
   display: flex;
   justify-content: center;
@@ -8,6 +8,7 @@ const StyledServiceIntroductionSection = styled.section`
   scroll-snap-align: start;
   position: relative;
   justify-content: space-evenly;
+  flex-wrap: wrap;
 `;
 
 const StyledTitle = styled.h1(
@@ -15,7 +16,7 @@ const StyledTitle = styled.h1(
   position: relative;
   text-align: left;
   font-size: 4rem;
-  margin-bottom: 2rem;
+  margin: 10rem 0 2rem;
   font-weight: 700;
   line-height: 4.4rem;
   letter-spacing: 0.4rem;
@@ -36,10 +37,14 @@ const StyledSubTitle = styled.span(
   font-size: 2rem;
   text-align: left;
   letter-spacing: 0.1rem; 
-  line-height: 2.4rem;
+  line-height: 2.8rem;
   color: ${theme.colors.BLACK_100};
 `
 );
+
+const StyledTitleContainer = styled.div`
+  padding: 4rem;
+`;
 
 const StyledServicesImage = styled.img`
   width: 67.6rem;
@@ -48,8 +53,9 @@ const StyledServicesImage = styled.img`
 
 export {
   StyledHighlightImage,
-  StyledServiceIntroductionSection,
+  StyledContainer,
   StyledServicesImage,
   StyledSubTitle,
-  StyledTitle
+  StyledTitle,
+  StyledTitleContainer
 };

--- a/frontend/src/pages/LandingPage/components/LandingServiceIntroductionSection/LandingServiceIntroductionSection.tsx
+++ b/frontend/src/pages/LandingPage/components/LandingServiceIntroductionSection/LandingServiceIntroductionSection.tsx
@@ -1,10 +1,11 @@
 import { HTMLAttributes } from 'react';
 import {
   StyledHighlightImage,
-  StyledServiceIntroductionSection,
+  StyledContainer,
   StyledServicesImage,
   StyledSubTitle,
-  StyledTitle
+  StyledTitle,
+  StyledTitleContainer
 } from './LandingServiceIntroductionSection.styles';
 
 import Services from '../../../../assets/services.svg';
@@ -15,9 +16,9 @@ interface Props extends HTMLAttributes<HTMLElement> {}
 
 function LandingServiceIntroductionSection({ id }: Props) {
   return (
-    <StyledServiceIntroductionSection id={id}>
+    <StyledContainer id={id}>
       <LandingNavbar />
-      <div>
+      <StyledTitleContainer>
         <StyledTitle>
           분산된 서비스...
           <br />
@@ -25,13 +26,15 @@ function LandingServiceIntroductionSection({ id }: Props) {
           <StyledHighlightImage src={CircleHighlight} alt="highlight" />
         </StyledTitle>
         <StyledSubTitle>
-          투표 하기, 일정 정하기... 분산 되어있는 서비스에 불편함을 느끼지 않으셨나요?
+          투표 하기, 일정 정하기...
+          <br />
+          분산 되어있는 서비스에 불편함을 느끼지 않으셨나요?
           <br />
           모락에 모두 모여있어요!
         </StyledSubTitle>
-      </div>
+      </StyledTitleContainer>
       <StyledServicesImage src={Services} alt="services" />
-    </StyledServiceIntroductionSection>
+    </StyledContainer>
   );
 }
 

--- a/frontend/src/styles/GlobalStyle.tsx
+++ b/frontend/src/styles/GlobalStyle.tsx
@@ -88,7 +88,13 @@ const style = css`
     html {
       font-size: 7px;
     }
-  };
+  }
+
+  @media screen and (max-width: 700px) {
+    html {
+      font-size: 4px;
+    }
+  }
 `
 
 function GlobalStyle() {

--- a/frontend/src/styles/GlobalStyle.tsx
+++ b/frontend/src/styles/GlobalStyle.tsx
@@ -33,7 +33,7 @@ const style = css`
   }
   
   html {
-    font-size: 10px;
+    font-size: 1.4vw;
     font-family: 'TmoneyRoundWindRegular', sans-serif;
   }
 
@@ -78,21 +78,27 @@ const style = css`
     outline: none;
   }
 
-  @media screen and (max-width: 1919px) {
-    html {
-      font-size: 8px;
-    }
-  }
-
-  @media screen and (max-width: 1366px) {
+  @media screen and (min-width: 500px) {
     html {
       font-size: 7px;
     }
   }
 
-  @media screen and (max-width: 700px) {
+  @media screen and (min-width: 1367px) {
     html {
-      font-size: 4px;
+      font-size: 8px;
+    }
+  }
+
+  @media screen and (min-width: 1700px) {
+    html {
+      font-size: 9px;
+    }
+  }
+
+  @media screen and (min-width: 1920px) {
+    html {
+      font-size: 10px;
     }
   }
 `

--- a/frontend/src/styles/GlobalStyle.tsx
+++ b/frontend/src/styles/GlobalStyle.tsx
@@ -31,12 +31,6 @@ const style = css`
     vertical-align: baseline;
     box-sizing: border-box;
   }
-  
-  html {
-    font-size: 1.4vw;
-    font-family: 'TmoneyRoundWindRegular', sans-serif;
-  }
-
 
   article, aside, details, figcaption, figure, 
   footer, header, hgroup, menu, nav, section {
@@ -76,6 +70,11 @@ const style = css`
 
   input:focus {
     outline: none;
+  }
+
+  html {
+    font-size: 1.4vw;
+    font-family: 'TmoneyRoundWindRegular', sans-serif;
   }
 
   @media screen and (min-width: 500px) {

--- a/frontend/src/utils/responsive.ts
+++ b/frontend/src/utils/responsive.ts
@@ -1,0 +1,15 @@
+const BREAK_POINT = {
+  NOT_MOBILE_MIN: 500
+};
+
+const mediaQuery = (size: string, styles: string) => `
+  @media ${size} {
+    ${styles};
+  }
+`;
+
+const responsive = {
+  mobile: (styles: string) => mediaQuery(`(max-width: ${BREAK_POINT.NOT_MOBILE_MIN - 1}px)`, styles)
+};
+
+export default responsive;


### PR DESCRIPTION
## 상세 내용
- 랜딩페이지가 모바일에서 깨지지 않게 대응해주었습니다. 
- 사이즈별로 대응 가능한 미디어 쿼리를 Globalstyle에 작성했습니다. 
- 미디어쿼리 사이즈에 따라 css 적용이 가능하도록, 유틸 함수를 분리해주었습니다. 
- 테스트 통과 완료! 
- 자세한 내용은 [개발일지](https://www.notion.so/ririhan/FE-59e0e4994dca4e4e833b8bc717e2bd30)를 참고해주세요 :) 

Close #386
