### PR TITLE
feat(appointment): 약속 진행 시간 표시 문구 변경

### DIFF
--- a/frontend/src/pages/AppointmentMainPage/components/AppointmentMainDetail/AppointmentMainDetail.tsx
+++ b/frontend/src/pages/AppointmentMainPage/components/AppointmentMainDetail/AppointmentMainDetail.tsx
@@ -3,6 +3,7 @@ import { useTheme } from '@emotion/react';
 import FlexContainer from '../../../../components/FlexContainer/FlexContainer';
 import TextField from '../../../../components/TextField/TextField';
 import { Appointment } from '../../../../types/appointment';
+import { getFormattedHourMinuteDuration } from '../../../../utils/date';
 import { StyledCloseTime, StyledDetail } from './AppointmentMainDetail.styles';
 
 const getFormattedClosedTime = (value: string) => {
@@ -25,6 +26,7 @@ type Props = {
 };
 
 function AppointmentMainDetail({ durationHours, durationMinutes, closedAt }: Props) {
+  console.log(durationHours, durationMinutes);
   const theme = useTheme();
 
   return (
@@ -42,9 +44,7 @@ function AppointmentMainDetail({ durationHours, durationMinutes, closedAt }: Pro
           colorScheme={theme.colors.PURPLE_100}
         >
           <StyledDetail>
-            {durationHours}
-            시간
-            {durationMinutes.toString().padStart(2, '0')}분
+            {getFormattedHourMinuteDuration(durationHours, durationMinutes)}
           </StyledDetail>
         </TextField>
       </FlexContainer>

--- a/frontend/src/pages/AppointmentMainPage/components/AppointmentMainDetail/AppointmentMainDetail.tsx
+++ b/frontend/src/pages/AppointmentMainPage/components/AppointmentMainDetail/AppointmentMainDetail.tsx
@@ -26,7 +26,6 @@ type Props = {
 };
 
 function AppointmentMainDetail({ durationHours, durationMinutes, closedAt }: Props) {
-  console.log(durationHours, durationMinutes);
   const theme = useTheme();
 
   return (

--- a/frontend/src/pages/AppointmentProgressPage/components/AppointmentProgressDetail/AppointmentProgressDetail.tsx
+++ b/frontend/src/pages/AppointmentProgressPage/components/AppointmentProgressDetail/AppointmentProgressDetail.tsx
@@ -1,4 +1,5 @@
 import { Appointment } from '../../../../types/appointment';
+import { getFormattedHourMinuteDuration } from '../../../../utils/date';
 import { StyledDuration } from './AppointmentProgressDetail.styles';
 
 type Props = {
@@ -11,8 +12,8 @@ type Props = {
 function AppointmentProgressDetail({ durationHours, durationMinutes, startTime, endTime }: Props) {
   return (
     <StyledDuration>
-      약속시간은 {durationHours}시간 {durationMinutes}분동안 진행
-      <br />({startTime}~{endTime})
+      약속 진행시간: {getFormattedHourMinuteDuration(durationHours, durationMinutes)} ({startTime}~
+      {endTime})
     </StyledDuration>
   );
 }

--- a/frontend/src/pages/AppointmentProgressPage/components/AppointmentProgressHeader/AppointmentProgressHeader.styles.tsx
+++ b/frontend/src/pages/AppointmentProgressPage/components/AppointmentProgressHeader/AppointmentProgressHeader.styles.tsx
@@ -11,8 +11,9 @@ const StyledHeader = styled.header`
   font-size: 4.8rem;
 `;
 
-const StyledDescription = styled.div`
+const StyledDescription = styled.p`
   font-size: 2.4rem;
+  padding: 0.4rem 0;
   overflow-y: auto;
 `;
 

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -14,4 +14,13 @@ const getFormattedDateTime = (dateTimeInput: string) => {
   return `${year}.${month}.${date}(${day}) ${hour}:${minutes}${period}`;
 };
 
-export { getFormattedDateTime };
+const getFormattedHourMinuteDuration = (hours: number, minutes: number) => {
+  const hourText = `${hours}시간`;
+  const minuteText = `${minutes}분`;
+
+  if (hours > 0 && minutes > 0) return hourText + minuteText;
+  if (hours > 0) return hourText;
+  if (minutes > 0) return minuteText;
+};
+
+export { getFormattedDateTime, getFormattedHourMinuteDuration };


### PR DESCRIPTION
## 상세 내용

- 약속 진행 시간 표시 문구를 변경해주었습니다!
![image](https://user-images.githubusercontent.com/64825713/196417609-a5b0cecb-c703-4070-b8d1-aec8d79751ce.png)

- 1시간 30분, 30분등의 형식의 string으로 포맷해주는 함수를 util로 만들어주었습니다. (약속잡기 메인 페이지에서도 사용되어서 추출해주었습니다.)

```typescript

const getFormattedHourMinuteDuration = (hours: number, minutes: number) => {
  const hourText = `${hours}시간`;
  const minuteText = `${minutes}분`;

  if (hours > 0 && minutes > 0) return hourText + minuteText;
  if (hours > 0) return hourText;
  if (minutes > 0) return minuteText;
};

```


Close #466 
