### PR TITLE
fix: 역할 중복 시에도 역할 정하기가 가능하도록 수정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -141,9 +141,7 @@ tasks.named('jacocoTestCoverageVerification') {
                     '**.RestSlackClient',
                     '**.*Config',
                     '**.*Performance*',
-                    '**.Proxy*',
-                    '**.*Request',
-                    '**.*Response'
+                    '**.Proxy*'
             ]
         }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -141,7 +141,9 @@ tasks.named('jacocoTestCoverageVerification') {
                     '**.RestSlackClient',
                     '**.*Config',
                     '**.*Performance*',
-                    '**.Proxy*'
+                    '**.Proxy*',
+                    '**.*Request',
+                    '**.*Response'
             ]
         }
 

--- a/backend/src/main/java/com/morak/back/role/application/RoleService.java
+++ b/backend/src/main/java/com/morak/back/role/application/RoleService.java
@@ -4,6 +4,7 @@ import com.morak.back.auth.domain.Member;
 import com.morak.back.auth.domain.MemberRepository;
 import com.morak.back.auth.exception.MemberNotFoundException;
 import com.morak.back.core.exception.CustomErrorCode;
+import com.morak.back.core.support.Generated;
 import com.morak.back.role.application.dto.RoleNameResponses;
 import com.morak.back.role.application.dto.RolesResponse;
 import com.morak.back.role.domain.RandomShuffleStrategy;
@@ -38,6 +39,7 @@ public class RoleService {
 
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Generated
     public void createDefaultRole(TeamCreateEvent event) {
         roleRepository.save(new Role(event.getTeamCode()));
     }

--- a/backend/src/main/java/com/morak/back/role/application/RoleService.java
+++ b/backend/src/main/java/com/morak/back/role/application/RoleService.java
@@ -4,7 +4,6 @@ import com.morak.back.auth.domain.Member;
 import com.morak.back.auth.domain.MemberRepository;
 import com.morak.back.auth.exception.MemberNotFoundException;
 import com.morak.back.core.exception.CustomErrorCode;
-import com.morak.back.core.support.Generated;
 import com.morak.back.role.application.dto.RoleNameResponses;
 import com.morak.back.role.application.dto.RolesResponse;
 import com.morak.back.role.domain.RandomShuffleStrategy;
@@ -39,7 +38,6 @@ public class RoleService {
 
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Generated
     public void createDefaultRole(TeamCreateEvent event) {
         roleRepository.save(new Role(event.getTeamCode()));
     }

--- a/backend/src/main/java/com/morak/back/role/application/RoleService.java
+++ b/backend/src/main/java/com/morak/back/role/application/RoleService.java
@@ -32,11 +32,10 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class RoleService {
 
     private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final RoleRepository roleRepository;
-    private final MemberRepository memberRepository;
 
-    // -- A
     public RoleNameResponses findRoleNames(String teamCode, Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, memberId));
@@ -45,7 +44,6 @@ public class RoleService {
         validateMemberInTeam(team, member);
 
         Role role = findRoleByTeamCode(teamCode);
-
         return RoleNameResponses.from(role.getRoleNames());
     }
 
@@ -73,7 +71,7 @@ public class RoleService {
         }
     }
 
-    public Long match(String teamCode, Long memberId) {
+    public Long matchRoleAndMember(String teamCode, Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, memberId));
         Team team = teamRepository.findByCode(teamCode)
@@ -108,7 +106,6 @@ public class RoleService {
         validateMemberInTeam(team, member);
 
         Role role = findRoleByTeamCode(teamCode);
-
         return RolesResponse.from(role.findAllGroupByDate());
     }
 }

--- a/backend/src/main/java/com/morak/back/role/application/RoleService.java
+++ b/backend/src/main/java/com/morak/back/role/application/RoleService.java
@@ -43,10 +43,8 @@ public class RoleService {
     }
 
     public RoleNameResponses findRoleNames(String teamCode, Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, memberId));
-        Team team = teamRepository.findByCode(teamCode)
-                .orElseThrow(() -> TeamNotFoundException.ofTeam(CustomErrorCode.TEAM_NOT_FOUND_ERROR, teamCode));
+        Member member = findMemberById(memberId);
+        Team team = findTeamByCode(teamCode);
         validateMemberInTeam(team, member);
 
         Role role = findRoleByTeamCode(teamCode);
@@ -54,10 +52,8 @@ public class RoleService {
     }
 
     public void editRoleNames(String teamCode, Long memberId, List<String> names) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, memberId));
-        Team team = teamRepository.findByCode(teamCode)
-                .orElseThrow(() -> TeamNotFoundException.ofTeam(CustomErrorCode.TEAM_NOT_FOUND_ERROR, teamCode));
+        Member member = findMemberById(memberId);
+        Team team = findTeamByCode(teamCode);
         validateMemberInTeam(team, member);
 
         Role role = findRoleByTeamCode(teamCode);
@@ -65,10 +61,8 @@ public class RoleService {
     }
 
     public Long matchRoleAndMember(String teamCode, Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, memberId));
-        Team team = teamRepository.findByCode(teamCode)
-                .orElseThrow(() -> TeamNotFoundException.ofTeam(CustomErrorCode.TEAM_NOT_FOUND_ERROR, teamCode));
+        Member member = findMemberById(memberId);
+        Team team = findTeamByCode(teamCode);
         validateMemberInTeam(team, member);
 
         List<Long> memberIds = findMemberIds(team);
@@ -85,14 +79,22 @@ public class RoleService {
     }
 
     public RolesResponse findHistories(String teamCode, Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, memberId));
-        Team team = teamRepository.findByCode(teamCode)
-                .orElseThrow(() -> TeamNotFoundException.ofTeam(CustomErrorCode.TEAM_NOT_FOUND_ERROR, teamCode));
+        Member member = findMemberById(memberId);
+        Team team = findTeamByCode(teamCode);
         validateMemberInTeam(team, member);
 
         Role role = findRoleByTeamCode(teamCode);
         return RolesResponse.from(role.findAllGroupByDate());
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> MemberNotFoundException.of(CustomErrorCode.MEMBER_NOT_FOUND_ERROR, memberId));
+    }
+
+    private Team findTeamByCode(String teamCode) {
+        return teamRepository.findByCode(teamCode)
+                .orElseThrow(() -> TeamNotFoundException.ofTeam(CustomErrorCode.TEAM_NOT_FOUND_ERROR, teamCode));
     }
 
     private Role findRoleByTeamCode(String teamCode) {

--- a/backend/src/main/java/com/morak/back/role/application/RoleService.java
+++ b/backend/src/main/java/com/morak/back/role/application/RoleService.java
@@ -20,7 +20,6 @@ import com.morak.back.team.exception.TeamAuthorizationException;
 import com.morak.back.team.exception.TeamNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.Generated;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -39,7 +38,6 @@ public class RoleService {
 
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @Generated
     public void createDefaultRole(TeamCreateEvent event) {
         roleRepository.save(new Role(event.getTeamCode()));
     }

--- a/backend/src/main/java/com/morak/back/role/application/RoleService.java
+++ b/backend/src/main/java/com/morak/back/role/application/RoleService.java
@@ -20,6 +20,7 @@ import com.morak.back.team.exception.TeamAuthorizationException;
 import com.morak.back.team.exception.TeamNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Generated;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -38,6 +39,7 @@ public class RoleService {
 
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Generated
     public void createDefaultRole(TeamCreateEvent event) {
         roleRepository.save(new Role(event.getTeamCode()));
     }

--- a/backend/src/main/java/com/morak/back/role/application/dto/HistoryResponse.java
+++ b/backend/src/main/java/com/morak/back/role/application/dto/HistoryResponse.java
@@ -32,8 +32,6 @@ public class HistoryResponse {
     private static Map<String, Long> getMatchResult(RoleHistory roleHistory) {
         return roleHistory.getMatchResult()
                 .entrySet().stream()
-                .collect(Collectors.toMap(
-                        it -> it.getKey().getValue(), Entry::getValue
-                ));
+                .collect(Collectors.toMap(entry -> entry.getKey().getValue(), Entry::getValue));
     }
 }

--- a/backend/src/main/java/com/morak/back/role/application/dto/HistoryResponse.java
+++ b/backend/src/main/java/com/morak/back/role/application/dto/HistoryResponse.java
@@ -3,8 +3,6 @@ package com.morak.back.role.application.dto;
 import com.morak.back.role.domain.RoleHistory;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,19 +17,16 @@ public class HistoryResponse {
     private List<RoleResponse> role;
 
     public static HistoryResponse from(RoleHistory roleHistory) {
-        Map<String, Long> matchResult = getMatchResult(roleHistory);
-
         return new HistoryResponse(
                 roleHistory.getDateTime().toLocalDate(),
-                matchResult.entrySet().stream()
-                        .map(RoleResponse::from)
-                        .collect(Collectors.toList())
+                toRoleResponses(roleHistory)
         );
     }
 
-    private static Map<String, Long> getMatchResult(RoleHistory roleHistory) {
-        return roleHistory.getMatchResult()
-                .entrySet().stream()
-                .collect(Collectors.toMap(entry -> entry.getKey().getValue(), Entry::getValue));
+    private static List<RoleResponse> toRoleResponses(RoleHistory roleHistory) {
+        return roleHistory.getMatchResults()
+                .stream()
+                .map(RoleResponse::from)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/morak/back/role/application/dto/RoleNameEditRequest.java
+++ b/backend/src/main/java/com/morak/back/role/application/dto/RoleNameEditRequest.java
@@ -1,6 +1,7 @@
 package com.morak.back.role.application.dto;
 
 import java.util.List;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,5 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RoleNameEditRequest {
 
+    @NotNull(message = "roles는 null 일 수 없습니다.")
     private List<String> roles;
 }

--- a/backend/src/main/java/com/morak/back/role/application/dto/RoleResponse.java
+++ b/backend/src/main/java/com/morak/back/role/application/dto/RoleResponse.java
@@ -1,5 +1,6 @@
 package com.morak.back.role.application.dto;
 
+import com.morak.back.core.support.Generated;
 import com.morak.back.role.domain.RoleMatchResult;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -24,6 +25,7 @@ public class RoleResponse {
     }
 
     @Override
+    @Generated
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -36,6 +38,7 @@ public class RoleResponse {
     }
 
     @Override
+    @Generated
     public int hashCode() {
         return Objects.hash(memberId, name);
     }

--- a/backend/src/main/java/com/morak/back/role/application/dto/RoleResponse.java
+++ b/backend/src/main/java/com/morak/back/role/application/dto/RoleResponse.java
@@ -1,5 +1,6 @@
 package com.morak.back.role.application.dto;
 
+import com.morak.back.role.domain.RoleMatchResult;
 import java.util.Map.Entry;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
@@ -16,6 +17,10 @@ public class RoleResponse {
 
     public static RoleResponse from(Entry<String, Long> matchResult) {
         return new RoleResponse(matchResult.getValue(), matchResult.getKey());
+    }
+
+    public static RoleResponse from(RoleMatchResult matchResult) {
+        return new RoleResponse(matchResult.getMemberId(), matchResult.getRoleName().getValue());
     }
 
     @Override

--- a/backend/src/main/java/com/morak/back/role/domain/RandomShuffleStrategy.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RandomShuffleStrategy.java
@@ -1,11 +1,13 @@
 package com.morak.back.role.domain;
 
+import com.morak.back.core.support.Generated;
 import java.util.Collections;
 import java.util.List;
 
 public class RandomShuffleStrategy implements ShuffleStrategy {
 
     @Override
+    @Generated
     public void shuffle(List<Long> memberIds) {
         Collections.shuffle(memberIds);
     }

--- a/backend/src/main/java/com/morak/back/role/domain/RoleHistories.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleHistories.java
@@ -10,21 +10,19 @@ import javax.persistence.Embeddable;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
+@NoArgsConstructor
 public class RoleHistories {
 
     @OneToMany(cascade = {CascadeType.PERSIST}, orphanRemoval = true)
     @JoinColumn(name = "role_id", nullable = false, updatable = false)
-    private List<RoleHistory> values;
+    private List<RoleHistory> values = new ArrayList<>();
 
     private RoleHistories(List<RoleHistory> values) {
         this.values = values;
-    }
-
-    public RoleHistories() {
-        this(new ArrayList<>());
     }
 
     public void add(RoleHistory roleHistory) {

--- a/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
@@ -1,7 +1,7 @@
 package com.morak.back.role.domain;
 
 import java.time.LocalDateTime;
-import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -11,7 +11,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.MapKeyColumn;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,14 +27,15 @@ public class RoleHistory implements Comparable<RoleHistory> {
     private LocalDateTime dateTime;
 
     @ElementCollection
-    @CollectionTable(name = "role_match_result", joinColumns = @JoinColumn(name = "role_history_id"))
-    @MapKeyColumn(name = "role_name")
-    @Column(name = "member_id", nullable = false)
-    private Map<RoleName, Long> matchResult;
+    @CollectionTable(
+            name = "role_match_result",
+            joinColumns = @JoinColumn(name = "role_history_id")
+    )
+    private List<RoleMatchResult> matchResults;
 
-    public RoleHistory(LocalDateTime dateTime, Map<RoleName, Long> matchResult) {
+    public RoleHistory(LocalDateTime dateTime, List<RoleMatchResult> matchResults) {
         this.dateTime = dateTime;
-        this.matchResult = matchResult;
+        this.matchResults = matchResults;
     }
 
     @Override
@@ -47,13 +47,13 @@ public class RoleHistory implements Comparable<RoleHistory> {
             return false;
         }
         RoleHistory that = (RoleHistory) o;
-        return Objects.equals(getDateTime(), that.getDateTime()) && Objects.equals(getMatchResult(),
-                that.getMatchResult());
+        return Objects.equals(getDateTime(), that.getDateTime()) && Objects.equals(getMatchResults(),
+                that.getMatchResults());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getDateTime(), getMatchResult());
+        return Objects.hash(getDateTime(), getMatchResults());
     }
 
     @Override

--- a/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
@@ -2,6 +2,7 @@ package com.morak.back.role.domain;
 
 import com.morak.back.core.support.Generated;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.persistence.CollectionTable;
@@ -32,7 +33,7 @@ public class RoleHistory implements Comparable<RoleHistory> {
             name = "role_match_result",
             joinColumns = @JoinColumn(name = "role_history_id")
     )
-    private List<RoleMatchResult> matchResults;
+    private List<RoleMatchResult> matchResults = new ArrayList<>();
 
     public RoleHistory(LocalDateTime dateTime, List<RoleMatchResult> matchResults) {
         this.dateTime = dateTime;

--- a/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
@@ -1,5 +1,6 @@
 package com.morak.back.role.domain;
 
+import com.morak.back.core.support.Generated;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -39,6 +40,7 @@ public class RoleHistory implements Comparable<RoleHistory> {
     }
 
     @Override
+    @Generated
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -52,11 +54,13 @@ public class RoleHistory implements Comparable<RoleHistory> {
     }
 
     @Override
+    @Generated
     public int hashCode() {
         return Objects.hash(getDateTime(), getMatchResults());
     }
 
     @Override
+    @Generated
     public int compareTo(RoleHistory other) {
         if (this.dateTime.isBefore(other.dateTime)) {
             return -1;

--- a/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
@@ -60,7 +60,6 @@ public class RoleHistory implements Comparable<RoleHistory> {
     }
 
     @Override
-    @Generated
     public int compareTo(RoleHistory other) {
         if (this.dateTime.isBefore(other.dateTime)) {
             return -1;

--- a/backend/src/main/java/com/morak/back/role/domain/RoleMatchResult.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleMatchResult.java
@@ -1,5 +1,6 @@
 package com.morak.back.role.domain;
 
+import com.morak.back.core.support.Generated;
 import java.util.Objects;
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -25,6 +26,7 @@ public class RoleMatchResult {
     }
 
     @Override
+    @Generated
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -37,6 +39,7 @@ public class RoleMatchResult {
     }
 
     @Override
+    @Generated
     public int hashCode() {
         return Objects.hash(roleName, memberId);
     }

--- a/backend/src/main/java/com/morak/back/role/domain/RoleMatchResult.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleMatchResult.java
@@ -1,7 +1,5 @@
 package com.morak.back.role.domain;
 
-import com.morak.back.core.support.Generated;
-import java.util.Objects;
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -23,24 +21,5 @@ public class RoleMatchResult {
     public RoleMatchResult(RoleName roleName, Long memberId) {
         this.roleName = roleName;
         this.memberId = memberId;
-    }
-
-    @Override
-    @Generated
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        RoleMatchResult that = (RoleMatchResult) o;
-        return Objects.equals(roleName, that.roleName) && Objects.equals(memberId, that.memberId);
-    }
-
-    @Override
-    @Generated
-    public int hashCode() {
-        return Objects.hash(roleName, memberId);
     }
 }

--- a/backend/src/main/java/com/morak/back/role/domain/RoleMatchResult.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleMatchResult.java
@@ -1,0 +1,43 @@
+package com.morak.back.role.domain;
+
+import java.util.Objects;
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor
+public class RoleMatchResult {
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "role_name"))
+    private RoleName roleName;
+
+    private Long memberId;
+
+    public RoleMatchResult(RoleName roleName, Long memberId) {
+        this.roleName = roleName;
+        this.memberId = memberId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RoleMatchResult that = (RoleMatchResult) o;
+        return Objects.equals(roleName, that.roleName) && Objects.equals(memberId, that.memberId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(roleName, memberId);
+    }
+}

--- a/backend/src/main/java/com/morak/back/role/domain/RoleMatchResult.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleMatchResult.java
@@ -1,7 +1,5 @@
 package com.morak.back.role.domain;
 
-import javax.persistence.AttributeOverride;
-import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
 import lombok.Getter;
@@ -13,7 +11,6 @@ import lombok.NoArgsConstructor;
 public class RoleMatchResult {
 
     @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "role_name"))
     private RoleName roleName;
 
     private Long memberId;

--- a/backend/src/main/java/com/morak/back/role/domain/RoleName.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleName.java
@@ -1,6 +1,7 @@
 package com.morak.back.role.domain;
 
 import com.morak.back.core.exception.CustomErrorCode;
+import com.morak.back.core.support.Generated;
 import com.morak.back.role.exception.RoleDomainLogicException;
 import java.util.Objects;
 import javax.persistence.Column;
@@ -36,6 +37,7 @@ public class RoleName {
     }
 
     @Override
+    @Generated
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -48,14 +50,8 @@ public class RoleName {
     }
 
     @Override
+    @Generated
     public int hashCode() {
         return Objects.hash(value);
-    }
-
-    @Override
-    public String toString() {
-        return "RoleName{" +
-                "value='" + value + '\'' +
-                '}';
     }
 }

--- a/backend/src/main/java/com/morak/back/role/domain/RoleName.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleName.java
@@ -4,17 +4,18 @@ import com.morak.back.core.exception.CustomErrorCode;
 import com.morak.back.core.support.Generated;
 import com.morak.back.role.exception.RoleDomainLogicException;
 import java.util.Objects;
+import javax.persistence.Access;
+import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 
 @Getter
-@Setter
 @Embeddable
 @NoArgsConstructor
+@Access(AccessType.FIELD)
 public class RoleName {
 
     private static final int MAX_LENGTH = 20;

--- a/backend/src/main/java/com/morak/back/role/domain/RoleName.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleName.java
@@ -7,11 +7,13 @@ import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 
-@NoArgsConstructor
-@Embeddable
 @Getter
+@Setter
+@Embeddable
+@NoArgsConstructor
 public class RoleName {
 
     private static final int MAX_LENGTH = 20;
@@ -31,10 +33,6 @@ public class RoleName {
                     value + "는 " + MAX_LENGTH + "자를 넘을 수 없습니다."
             );
         }
-    }
-
-    public String getValue() {
-        return value;
     }
 
     @Override
@@ -60,6 +58,4 @@ public class RoleName {
                 "value='" + value + '\'' +
                 '}';
     }
-
-
 }

--- a/backend/src/main/java/com/morak/back/role/domain/RoleNames.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleNames.java
@@ -44,10 +44,10 @@ public class RoleNames {
 
     public Map<RoleName, Long> match(List<Long> memberIds) {
         validateMemberCount(memberIds.size());
-        return IntStream.range(0, values.size())
+        return IntStream.range(0, this.values.size())
                 .boxed()
                 .collect(Collectors.toMap(
-                        values::get,
+                        this.values::get,
                         memberIds::get
                 ));
     }

--- a/backend/src/main/java/com/morak/back/role/domain/RoleNames.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleNames.java
@@ -3,7 +3,6 @@ package com.morak.back.role.domain;
 import com.morak.back.core.exception.CustomErrorCode;
 import com.morak.back.role.exception.RoleDomainLogicException;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.persistence.CollectionTable;
@@ -42,14 +41,11 @@ public class RoleNames {
         }
     }
 
-    public Map<RoleName, Long> match(List<Long> memberIds) {
+    public List<RoleMatchResult> match(List<Long> memberIds) {
         validateMemberCount(memberIds.size());
         return IntStream.range(0, this.values.size())
-                .boxed()
-                .collect(Collectors.toMap(
-                        this.values::get,
-                        memberIds::get
-                ));
+                .mapToObj(idx -> new RoleMatchResult(this.values.get(idx), memberIds.get(idx)))
+                .collect(Collectors.toList());
     }
 
     private void validateMemberCount(int size) {

--- a/backend/src/main/java/com/morak/back/role/domain/RoleNames.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleNames.java
@@ -44,7 +44,7 @@ public class RoleNames {
     public List<RoleMatchResult> match(List<Long> memberIds) {
         validateMemberCount(memberIds.size());
         return IntStream.range(0, this.values.size())
-                .mapToObj(idx -> new RoleMatchResult(this.values.get(idx), memberIds.get(idx)))
+                .mapToObj(index -> new RoleMatchResult(this.values.get(index), memberIds.get(index)))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/morak/back/role/domain/RoleNames.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleNames.java
@@ -2,6 +2,7 @@ package com.morak.back.role.domain;
 
 import com.morak.back.core.exception.CustomErrorCode;
 import com.morak.back.role.exception.RoleDomainLogicException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -19,7 +20,7 @@ public class RoleNames {
 
     @ElementCollection
     @CollectionTable(name = "role_name", joinColumns = @JoinColumn(name = "role_id"))
-    private List<RoleName> values;
+    private List<RoleName> values = new ArrayList<>();
 
     public RoleNames(List<RoleName> values) {
         validateMinSize(values.size());

--- a/backend/src/main/java/com/morak/back/role/domain/RoleNames.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleNames.java
@@ -6,7 +6,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.persistence.AttributeOverride;
 import javax.persistence.CollectionTable;
+import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
 import javax.persistence.JoinColumn;
@@ -20,6 +22,7 @@ public class RoleNames {
 
     @ElementCollection
     @CollectionTable(name = "role_name", joinColumns = @JoinColumn(name = "role_id"))
+    @AttributeOverride(name = "value", column = @Column(name = "name"))
     private List<RoleName> values = new ArrayList<>();
 
     public RoleNames(List<RoleName> values) {

--- a/backend/src/main/java/com/morak/back/role/domain/RoleRepository.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleRepository.java
@@ -5,20 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoleRepository extends JpaRepository<Role, Long> {
 
-    // -- A
-
-
-
-    // -- B
-
-
-
-    // -- C
     Optional<Role> findByTeamCode(String teamCode);
-
-
-
-    // -- D
-
-
 }

--- a/backend/src/main/java/com/morak/back/role/domain/RoleRepository.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleRepository.java
@@ -1,9 +1,11 @@
 package com.morak.back.role.domain;
 
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.Repository;
 
-public interface RoleRepository extends JpaRepository<Role, Long> {
+public interface RoleRepository extends Repository<Role, Long> {
+
+    Role save(Role role);
 
     Optional<Role> findByTeamCode(String teamCode);
 }

--- a/backend/src/main/java/com/morak/back/role/exception/RoleNotFoundException.java
+++ b/backend/src/main/java/com/morak/back/role/exception/RoleNotFoundException.java
@@ -8,8 +8,4 @@ public class RoleNotFoundException extends ResourceNotFoundException {
     public RoleNotFoundException(CustomErrorCode code, String logMessage) {
         super(code, logMessage);
     }
-
-    public static RoleNotFoundException ofTeam(CustomErrorCode code, String teamCode) {
-        return new RoleNotFoundException(code, teamCode + " 코드의 팀에 속한 역할은 찾을 수 없습니다.");
-    }
 }

--- a/backend/src/main/java/com/morak/back/role/ui/RoleController.java
+++ b/backend/src/main/java/com/morak/back/role/ui/RoleController.java
@@ -9,7 +9,6 @@ import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@Validated
 @RequestMapping("/api/groups/{groupCode}/roles")
 public class RoleController {
 

--- a/backend/src/main/java/com/morak/back/role/ui/RoleController.java
+++ b/backend/src/main/java/com/morak/back/role/ui/RoleController.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,38 +20,35 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/api/groups/{groupCode}/roles")
 public class RoleController {
 
     private final RoleService roleService;
 
     @GetMapping("/names")
-    public ResponseEntity<RoleNameResponses> findRoleNames(@PathVariable String groupCode,
-                                           @Auth Long memberId) {
+    public ResponseEntity<RoleNameResponses> findRoleNames(@PathVariable String groupCode, @Auth Long memberId) {
         RoleNameResponses roleNames = roleService.findRoleNames(groupCode, memberId);
         return ResponseEntity.ok(roleNames);
-
     }
 
     @PutMapping("/names")
-    public ResponseEntity<Void> doPoll(@PathVariable String groupCode,
-                                       @Auth Long memberId,
-                                       @Valid @RequestBody RoleNameEditRequest request) {
+    public ResponseEntity<Void> editRoleNames(@PathVariable String groupCode,
+                                              @Auth Long memberId,
+                                              @Valid @RequestBody RoleNameEditRequest request) {
         roleService.editRoleNames(groupCode, memberId, request.getRoles());
         return ResponseEntity.ok().build();
     }
 
     @PostMapping
-    public ResponseEntity<Void> create(@PathVariable String groupCode, @Auth Long memberId) {
-        Long roleId = roleService.match(groupCode, memberId);
+    public ResponseEntity<Void> matchRoleAndMember(@PathVariable String groupCode, @Auth Long memberId) {
+        Long roleId = roleService.matchRoleAndMember(groupCode, memberId);
         return ResponseEntity.created(URI.create("/api/groups/" + groupCode + "/roles/" + roleId)).build();
     }
 
     @GetMapping("/histories")
-    public ResponseEntity<RolesResponse> getHistories(@PathVariable String groupCode, @Auth Long memberId) {
+    public ResponseEntity<RolesResponse> findHistories(@PathVariable String groupCode, @Auth Long memberId) {
         RolesResponse histories = roleService.findHistories(groupCode, memberId);
         return ResponseEntity.ok(histories);
     }
-
-
 }

--- a/backend/src/main/resources/schema-dev.sql
+++ b/backend/src/main/resources/schema-dev.sql
@@ -173,7 +173,7 @@ CREATE TABLE role_match_result
 CREATE TABLE role_name
 (
     `role_id`   BIGINT       NOT NULL,
-    `role_name` VARCHAR(255) NOT NULL
+    `name` VARCHAR(255) NOT NULL
 );
 
 CREATE TABLE role_history

--- a/backend/src/main/resources/schema-dev.sql
+++ b/backend/src/main/resources/schema-dev.sql
@@ -1,6 +1,6 @@
-DROP TABLE IF EXISTS role_match_result;
 DROP TABLE IF EXISTS role_history;
 DROP TABLE IF EXISTS role_name;
+DROP TABLE IF EXISTS role_match_result;
 DROP TABLE IF EXISTS role;
 DROP TABLE IF EXISTS poll_result;
 DROP TABLE IF EXISTS poll_item;
@@ -28,7 +28,7 @@ CREATE TABLE team
 (
     `id`         bigint       NOT NULL AUTO_INCREMENT,
     `name`       varchar(255) NOT NULL,
-    `code`       varchar(255) NOT NULL UNIQUE UNIQUE,
+    `code`       varchar(255) NOT NULL UNIQUE,
     `created_at` datetime     NOT NULL,
     `updated_at` datetime     NOT NULL,
     PRIMARY KEY (id)
@@ -154,6 +154,7 @@ CREATE TABLE slack_webhook
     FOREIGN KEY (team_id) REFERENCES team (id)
 );
 
+
 CREATE TABLE role
 (
     `id`        BIGINT       NOT NULL AUTO_INCREMENT,
@@ -166,7 +167,7 @@ CREATE TABLE role_match_result
     `role_history_id` BIGINT       NOT NULL,
     `member_id`       BIGINT       NOT NULL,
     `role_name`       VARCHAR(255) NOT NULL,
-    PRIMARY KEY (`role_history_id`, `role_name`)
+    PRIMARY KEY (`role_history_id`, `member_id`, `role_name`)
 );
 
 CREATE TABLE role_name

--- a/backend/src/main/resources/schema-local.sql
+++ b/backend/src/main/resources/schema-local.sql
@@ -173,7 +173,7 @@ CREATE TABLE role_match_result
 CREATE TABLE role_name
 (
     `role_id`   BIGINT       NOT NULL,
-    `role_name` VARCHAR(255) NOT NULL
+    `name` VARCHAR(255) NOT NULL
 );
 
 CREATE TABLE role_history

--- a/backend/src/main/resources/schema-local.sql
+++ b/backend/src/main/resources/schema-local.sql
@@ -1,6 +1,6 @@
-DROP TABLE IF EXISTS role_match_result;
 DROP TABLE IF EXISTS role_history;
 DROP TABLE IF EXISTS role_name;
+DROP TABLE IF EXISTS role_match_result;
 DROP TABLE IF EXISTS role;
 DROP TABLE IF EXISTS poll_result;
 DROP TABLE IF EXISTS poll_item;
@@ -154,6 +154,7 @@ CREATE TABLE slack_webhook
     FOREIGN KEY (team_id) REFERENCES team (id)
 );
 
+
 CREATE TABLE role
 (
     `id`        BIGINT       NOT NULL AUTO_INCREMENT,
@@ -166,7 +167,7 @@ CREATE TABLE role_match_result
     `role_history_id` BIGINT       NOT NULL,
     `member_id`       BIGINT       NOT NULL,
     `role_name`       VARCHAR(255) NOT NULL,
-    PRIMARY KEY (`role_history_id`, `role_name`)
+    PRIMARY KEY (`role_history_id`, `member_id`, `role_name`)
 );
 
 CREATE TABLE role_name

--- a/backend/src/test/java/com/morak/back/role/acceptance/RoleAcceptanceTest.java
+++ b/backend/src/test/java/com/morak/back/role/acceptance/RoleAcceptanceTest.java
@@ -117,6 +117,25 @@ public class RoleAcceptanceTest extends AcceptanceTest {
         );
     }
 
+    @Test
+    void 중복된_역할이_있을_때_역할을_매칭한다() {
+        // given
+        String teamInvitationLocation = 그룹_초대코드_생성을_요청한다(teamLocation, token).header("Location");
+        String otherToken = tokenProvider.createToken(String.valueOf(2L));
+        그룹_참가를_요청한다(teamInvitationLocation, otherToken);
+
+        RoleNameEditRequest roleNameEditRequest = new RoleNameEditRequest(List.of("엘사모", "엘사모"));
+        역할정하기_이름_목록_수정(roleNameEditRequest);
+
+        // when
+        ExtractableResponse<Response> response = 역할_매칭을_요청();
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(response.header("Location")).contains(teamLocation + "/roles/")
+        );
+    }
 
     @Test
     void 역할을_매칭하는데_역할이_멤버보다_많을_경우_BAD_REQUEST를_응답한다() {

--- a/backend/src/test/java/com/morak/back/role/acceptance/RoleAcceptanceTest.java
+++ b/backend/src/test/java/com/morak/back/role/acceptance/RoleAcceptanceTest.java
@@ -62,7 +62,7 @@ public class RoleAcceptanceTest extends AcceptanceTest {
     @Test
     void 역할_목록을_조회한다() {
         // when
-        ExtractableResponse<Response> response = 역할_이름들을_조회();
+        ExtractableResponse<Response> response = 역할_이름들을_조회한다();
         RoleNameResponses roleNameResponses = toObject(response, RoleNameResponses.class);
 
         // then
@@ -80,10 +80,10 @@ public class RoleAcceptanceTest extends AcceptanceTest {
         그룹_참가를_요청한다(teamInvitationLocation, otherToken);
 
         RoleNameEditRequest roleNameEditRequest = new RoleNameEditRequest(List.of("서기", "타임키퍼"));
-        역할정하기_이름_목록_수정(roleNameEditRequest);
+        역할정하기_이름_목록_수정을_요청한다(roleNameEditRequest);
 
         // when
-        ExtractableResponse<Response> response = 역할_이름들을_조회();
+        ExtractableResponse<Response> response = 역할_이름들을_조회한다();
         RoleNameResponses roleNameResponses = toObject(response, RoleNameResponses.class);
 
         // then
@@ -99,7 +99,7 @@ public class RoleAcceptanceTest extends AcceptanceTest {
         RoleNameEditRequest request = new RoleNameEditRequest(List.of("서기", "타임키퍼"));
 
         // when
-        ExtractableResponse<Response> response = 역할정하기_이름_목록_수정(request);
+        ExtractableResponse<Response> response = 역할정하기_이름_목록_수정을_요청한다(request);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -108,7 +108,7 @@ public class RoleAcceptanceTest extends AcceptanceTest {
     @Test
     void 역할을_매칭한다() {
         // when
-        ExtractableResponse<Response> response = 역할_매칭을_요청();
+        ExtractableResponse<Response> response = 역할_매칭을_요청한다();
 
         // then
         Assertions.assertAll(
@@ -125,10 +125,10 @@ public class RoleAcceptanceTest extends AcceptanceTest {
         그룹_참가를_요청한다(teamInvitationLocation, otherToken);
 
         RoleNameEditRequest roleNameEditRequest = new RoleNameEditRequest(List.of("엘사모", "엘사모"));
-        역할정하기_이름_목록_수정(roleNameEditRequest);
+        역할정하기_이름_목록_수정을_요청한다(roleNameEditRequest);
 
         // when
-        ExtractableResponse<Response> response = 역할_매칭을_요청();
+        ExtractableResponse<Response> response = 역할_매칭을_요청한다();
 
         // then
         Assertions.assertAll(
@@ -141,10 +141,10 @@ public class RoleAcceptanceTest extends AcceptanceTest {
     void 역할을_매칭하는데_역할이_멤버보다_많을_경우_BAD_REQUEST를_응답한다() {
         // given
         RoleNameEditRequest roleNameEditRequest = new RoleNameEditRequest(List.of("서기", "타임키퍼"));
-        역할정하기_이름_목록_수정(roleNameEditRequest);
+        역할정하기_이름_목록_수정을_요청한다(roleNameEditRequest);
 
         // when
-        ExtractableResponse<Response> response = 역할_매칭을_요청();
+        ExtractableResponse<Response> response = 역할_매칭을_요청한다();
 
         // then
         Assertions.assertAll(
@@ -161,11 +161,11 @@ public class RoleAcceptanceTest extends AcceptanceTest {
         String otherToken = tokenProvider.createToken(String.valueOf(2L));
         그룹_참가를_요청한다(teamInvitationLocation, otherToken);
 
-        역할_매칭을_요청();
-        역할_매칭을_요청();
+        역할_매칭을_요청한다();
+        역할_매칭을_요청한다();
 
         // when
-        ExtractableResponse<Response> response = 역할_히스토리를_조회();
+        ExtractableResponse<Response> response = 역할_히스토리_조회를_요청한다();
         RolesResponse rolesResponse = toObject(response, RolesResponse.class);
 
         // then
@@ -175,19 +175,19 @@ public class RoleAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    private ExtractableResponse<Response> 역할_이름들을_조회() {
+    private ExtractableResponse<Response> 역할_이름들을_조회한다() {
         return get(teamLocation + "/roles/names", toHeader(token));
     }
 
-    private ExtractableResponse<Response> 역할정하기_이름_목록_수정(RoleNameEditRequest request) {
+    private ExtractableResponse<Response> 역할정하기_이름_목록_수정을_요청한다(RoleNameEditRequest request) {
         return put(teamLocation + "/roles/names", request, toHeader(token));
     }
 
-    private ExtractableResponse<Response> 역할_매칭을_요청() {
+    private ExtractableResponse<Response> 역할_매칭을_요청한다() {
         return post(teamLocation + "/roles", toHeader(token));
     }
 
-    private ExtractableResponse<Response> 역할_히스토리를_조회() {
+    private ExtractableResponse<Response> 역할_히스토리_조회를_요청한다() {
         return get(teamLocation + "/roles/histories", toHeader(token));
     }
 }

--- a/backend/src/test/java/com/morak/back/role/acceptance/RoleAcceptanceTest.java
+++ b/backend/src/test/java/com/morak/back/role/acceptance/RoleAcceptanceTest.java
@@ -7,6 +7,8 @@ import static com.morak.back.SimpleRestAssured.post;
 import static com.morak.back.SimpleRestAssured.put;
 import static com.morak.back.SimpleRestAssured.toObject;
 import static com.morak.back.team.acceptance.TeamAcceptanceTest.그룹_생성을_요청한다;
+import static com.morak.back.team.acceptance.TeamAcceptanceTest.그룹_참가를_요청한다;
+import static com.morak.back.team.acceptance.TeamAcceptanceTest.그룹_초대코드_생성을_요청한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.morak.back.AcceptanceTest;
@@ -31,8 +33,8 @@ public class RoleAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private TokenProvider tokenProvider;
-    private String token;
 
+    private String token;
     private String teamLocation;
 
     @BeforeEach
@@ -42,17 +44,16 @@ public class RoleAcceptanceTest extends AcceptanceTest {
         teamLocation = 그룹_생성을_요청한다(new TeamCreateRequest("그룹"), token).header("Location");
     }
 
-
     @Test
     void 역할_목록을_조회한다() {
         // when
-        ExtractableResponse<Response> response = 역할_이름들을_조회(token);
+        ExtractableResponse<Response> response = 역할_이름들을_조회();
         RoleNameResponses roleNameResponses = toObject(response, RoleNameResponses.class);
 
         // then
         Assertions.assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(roleNameResponses.getRoles()).containsExactly("데일리 마스터", "반장", "청소부")
+                () -> assertThat(roleNameResponses.getRoles()).containsExactly("데일리 마스터")
         );
     }
 
@@ -75,7 +76,7 @@ public class RoleAcceptanceTest extends AcceptanceTest {
         RoleNameEditRequest request = new RoleNameEditRequest(List.of("서기", "타임키퍼"));
 
         // when
-        ExtractableResponse<Response> response = 역할정하기_이름_목록_수정(request, token);
+        ExtractableResponse<Response> response = 역할정하기_이름_목록_수정(request);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -84,7 +85,7 @@ public class RoleAcceptanceTest extends AcceptanceTest {
     @Test
     void 역할을_매칭한다() {
         // when
-        ExtractableResponse<Response> response = 역할_매칭을_요청(token);
+        ExtractableResponse<Response> response = 역할_매칭을_요청();
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -94,36 +95,34 @@ public class RoleAcceptanceTest extends AcceptanceTest {
     @Test
     void 역할_히스토리를_조회한다() {
         // given
-        String[] splitLocation = teamLocation.split("/");
-        String teamCode = splitLocation[splitLocation.length - 1];
+        String teamInvitationLocation = 그룹_초대코드_생성을_요청한다(teamLocation, token).header("Location");
+        String otherToken = tokenProvider.createToken(String.valueOf(2L));
+        그룹_참가를_요청한다(teamInvitationLocation, otherToken);
 
-        RoleNameEditRequest request = new RoleNameEditRequest(List.of("서기", "타임키퍼"));
-        역할정하기_이름_목록_수정(request, token);
-
-        역할_매칭을_요청(token);
-        역할_매칭을_요청(token);
+        역할_매칭을_요청();
+        역할_매칭을_요청();
 
         // when
-        ExtractableResponse<Response> response = 역할_히스토리를_조회(token);
+        ExtractableResponse<Response> response = 역할_히스토리를_조회();
         RolesResponse rolesResponse = toObject(response, RolesResponse.class);
 
         // then
         assertThat(rolesResponse.getRoles()).hasSize(1);
     }
 
-    private ExtractableResponse<Response> 역할_매칭을_요청(String token) {
+    private ExtractableResponse<Response> 역할_이름들을_조회() {
+        return get(teamLocation + "/roles/names", toHeader(token));
+    }
+
+    private ExtractableResponse<Response> 역할정하기_이름_목록_수정(RoleNameEditRequest request) {
+        return put(teamLocation + "/roles/names", request, toHeader(token));
+    }
+
+    private ExtractableResponse<Response> 역할_매칭을_요청() {
         return post(teamLocation + "/roles", toHeader(token));
     }
 
-    private ExtractableResponse<Response> 역할정하기_이름_목록_수정(RoleNameEditRequest request, String token) {
-        return put("/api/groups/MoraK123/roles/names", request, toHeader(token));
-    }
-
-    private ExtractableResponse<Response> 역할_이름들을_조회(String token) {
-        return get("/api/groups/MoraK123/roles/names", toHeader(token));
-    }
-
-    private ExtractableResponse<Response> 역할_히스토리를_조회(String token) {
+    private ExtractableResponse<Response> 역할_히스토리를_조회() {
         return get(teamLocation + "/roles/histories", toHeader(token));
     }
 }

--- a/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
@@ -17,6 +17,7 @@ import com.morak.back.role.domain.RoleHistory;
 import com.morak.back.role.domain.RoleName;
 import com.morak.back.role.domain.RoleNames;
 import com.morak.back.role.domain.RoleRepository;
+import com.morak.back.role.exception.RoleDomainLogicException;
 import com.morak.back.role.exception.RoleNotFoundException;
 import com.morak.back.support.ServiceTest;
 import com.morak.back.team.domain.Team;
@@ -149,6 +150,19 @@ class RoleServiceTest {
                 .isInstanceOf(RoleNotFoundException.class)
                 .extracting("code")
                 .isEqualTo(CustomErrorCode.ROLE_NOT_FOUND_ERROR);
+    }
+
+    @Test
+    void 역할을_매칭하는데_역할이_멤버보다_많을_경우_예외를_던진다() {
+        // given
+        roleRepository.save(new Role(team.getCode()));
+        roleService.editRoleNames(team.getCode(), member.getId(), List.of("서기", "타임키퍼"));
+
+        // when & then
+        assertThatThrownBy(() -> roleService.matchRoleAndMember(team.getCode(), member.getId()))
+                .isInstanceOf(RoleDomainLogicException.class)
+                .extracting("code")
+                .isEqualTo(CustomErrorCode.ROLE_NAMES_MAX_SIZE_ERROR);
     }
 
     @Test

--- a/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import com.morak.back.auth.domain.Member;
 import com.morak.back.auth.domain.MemberRepository;
+import com.morak.back.auth.exception.MemberNotFoundException;
 import com.morak.back.core.domain.Code;
 import com.morak.back.core.exception.CustomErrorCode;
 import com.morak.back.role.application.dto.RoleNameResponses;
@@ -26,6 +27,7 @@ import com.morak.back.team.domain.TeamMember;
 import com.morak.back.team.domain.TeamMemberRepository;
 import com.morak.back.team.domain.TeamRepository;
 import com.morak.back.team.exception.TeamAuthorizationException;
+import com.morak.back.team.exception.TeamNotFoundException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -106,6 +108,30 @@ class RoleServiceTest {
                 .isInstanceOf(TeamAuthorizationException.class)
                 .extracting("code")
                 .isEqualTo(CustomErrorCode.TEAM_MEMBER_MISMATCHED_ERROR);
+    }
+
+    @Test
+    void 역할_이름_목록을_조회할_때_멤버가_없는_경우_예외를_던진다() {
+        // given
+        roleRepository.save(new Role(team.getCode()));
+
+        // when & then
+        assertThatThrownBy(() -> roleService.editRoleNames(team.getCode(), 100L, List.of("서기", "타임키퍼")))
+                .isInstanceOf(MemberNotFoundException.class)
+                .extracting("code")
+                .isEqualTo(CustomErrorCode.MEMBER_NOT_FOUND_ERROR);
+    }
+
+    @Test
+    void 역할_이름_목록을_조회할_때_팀이_없는_경우_예외를_던진다() {
+        // given
+        roleRepository.save(new Role(team.getCode()));
+
+        // when & then
+        assertThatThrownBy(() -> roleService.editRoleNames("123456ll", member.getId(), List.of("서기", "타임키퍼")))
+                .isInstanceOf(TeamNotFoundException.class)
+                .extracting("code")
+                .isEqualTo(CustomErrorCode.TEAM_NOT_FOUND_ERROR);
     }
 
     @Test

--- a/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
@@ -125,6 +125,20 @@ class RoleServiceTest {
     }
 
     @Test
+    void 역할의_이름_목록을_수정할_때_멤버가_팀에_속하지_않는_경우_예외를_던진다() {
+        // given
+        Member otherMember = saveOtherMember();
+
+        roleRepository.save(new Role(team.getCode()));
+
+        // when & then
+        assertThatThrownBy(() -> roleService.editRoleNames(team.getCode(), otherMember.getId(), List.of("서기", "타임키퍼")))
+                .isInstanceOf(TeamAuthorizationException.class)
+                .extracting("code")
+                .isEqualTo(CustomErrorCode.TEAM_MEMBER_MISMATCHED_ERROR);
+    }
+
+    @Test
     void 중복된_이름으로_역할의_이름_목록을_수정한다() {
         // given
         roleRepository.save(new Role(team.getCode()));

--- a/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
@@ -30,6 +30,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -150,7 +151,7 @@ class RoleServiceTest {
     }
 
     @Test
-    void 역할을_매칭한다() {
+    void 역할을_매칭한다(@Autowired EntityManager em) {
         // given
         Member otherMember = saveOtherMember();
         teamMemberRepository.save(new TeamMember(null, team, otherMember));
@@ -162,7 +163,7 @@ class RoleServiceTest {
         // when
         roleService.matchRoleAndMember(team.getCode(), member.getId());
 
-        roleRepository.flush(); // 테스트에서는 flush()를 해야 history의 id 값을 얻어올 수 있다.
+        em.flush(); // 테스트에서는 flush()를 해야 history의 id 값을 얻어올 수 있다.
 
         // then
         RoleHistories afterHistories = role.getRoleHistories();
@@ -173,7 +174,7 @@ class RoleServiceTest {
     }
 
     @Test
-    void 중복된_역할이_있을_때_역할을_매칭한다() {
+    void 중복된_역할이_있을_때_역할을_매칭한다(@Autowired EntityManager em) {
         // given
         Member otherMember = saveOtherMember();
         teamMemberRepository.save(new TeamMember(null, team, otherMember));
@@ -186,7 +187,7 @@ class RoleServiceTest {
         // when
         roleService.matchRoleAndMember(team.getCode(), member.getId());
 
-        roleRepository.flush();
+        em.flush();
 
         // then
         RoleHistories afterHistories = role.getRoleHistories();
@@ -219,10 +220,10 @@ class RoleServiceTest {
     }
 
     @Test
-    void 역할_히스토리_목록을_조회한다() {
+    void 역할_히스토리_목록을_조회한다(@Autowired EntityManager em) {
         // given
         saveRolewithHistories();
-        roleRepository.flush();
+        em.flush();
 
         // when
         RolesResponse rolesResponse = roleService.findHistories(team.getCode(), member.getId());

--- a/backend/src/test/java/com/morak/back/role/domain/RoleHistoriesTest.java
+++ b/backend/src/test/java/com/morak/back/role/domain/RoleHistoriesTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -18,10 +17,10 @@ class RoleHistoriesTest {
         RoleName 서기 = new RoleName("서기");
         RoleHistories roleHistories = new RoleHistories();
 
-        RoleHistory history1 = new RoleHistory(now, Map.of(데일리_마스터, 1L));
-        RoleHistory history2 = new RoleHistory(now.plusSeconds(10), Map.of(서기, 2L));
-        RoleHistory history3 = new RoleHistory(now.minusDays(1), Map.of(데일리_마스터, 2L));
-        RoleHistory history4 = new RoleHistory(now.minusDays(1).plusSeconds(10), Map.of(서기, 1L));
+        RoleHistory history1 = new RoleHistory(now, List.of(new RoleMatchResult(데일리_마스터, 1L)));
+        RoleHistory history2 = new RoleHistory(now.plusSeconds(10), List.of(new RoleMatchResult(서기, 2L)));
+        RoleHistory history3 = new RoleHistory(now.minusDays(1), List.of(new RoleMatchResult(데일리_마스터, 2L)));
+        RoleHistory history4 = new RoleHistory(now.minusDays(1).plusSeconds(10), List.of(new RoleMatchResult(서기, 1L)));
 
         roleHistories.add(history1);
         roleHistories.add(history2);
@@ -30,6 +29,7 @@ class RoleHistoriesTest {
 
         // when
         List<RoleHistory> histories = roleHistories.findAllGroupByDate();
+
         // then
         Assertions.assertAll(
                 () -> assertThat(histories).hasSize(2),

--- a/backend/src/test/java/com/morak/back/role/domain/RoleHistoriesTest.java
+++ b/backend/src/test/java/com/morak/back/role/domain/RoleHistoriesTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 class RoleHistoriesTest {
 
-
     @Test
     void 날짜별로_최신의_히스토리만_반환한다() {
         // given

--- a/backend/src/test/java/com/morak/back/role/domain/RoleHistoryTest.java
+++ b/backend/src/test/java/com/morak/back/role/domain/RoleHistoryTest.java
@@ -1,0 +1,25 @@
+package com.morak.back.role.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+class RoleHistoryTest {
+
+    @Test
+    void RoleHistory는_dateTime에_따라_크기_비교가_된다() {
+        // given
+        RoleHistory roleHistoryA = new RoleHistory(LocalDateTime.now(), new ArrayList<>());
+        RoleHistory roleHistoryB = new RoleHistory(LocalDateTime.now().plusDays(1), new ArrayList<>());
+        RoleHistory roleHistoryC = new RoleHistory(LocalDateTime.now().plusDays(2), new ArrayList<>());
+
+        // when & then
+        assertAll(
+                () -> assertThat(roleHistoryB).isGreaterThan(roleHistoryA),
+                () -> assertThat(roleHistoryB).isLessThan(roleHistoryC)
+        );
+    }
+}

--- a/backend/src/test/java/com/morak/back/role/domain/RoleRepositoryTest.java
+++ b/backend/src/test/java/com/morak/back/role/domain/RoleRepositoryTest.java
@@ -14,10 +14,6 @@ class RoleRepositoryTest {
     @Autowired
     private RoleRepository roleRepository;
 
-    // -- A
-
-    // -- B
-
     @Test
     void 역할_이름을_수정한다() {
         // given
@@ -34,10 +30,4 @@ class RoleRepositoryTest {
                 () -> assertThat(values).containsExactly(new RoleName("서기"), new RoleName("타임키퍼"))
         );
     }
-
-    // -- C
-
-    // -- D
-
-
 }

--- a/backend/src/test/java/com/morak/back/role/domain/RoleTest.java
+++ b/backend/src/test/java/com/morak/back/role/domain/RoleTest.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,23 @@ class RoleTest {
     }
 
     @Test
-    void 역할을_정한다() {
+    void 역할의_이름은_중복될_수_있다() {
+        // given
+        Role role = new Role("TestTeam");
+
+        // when
+        role.updateNames(List.of("카메라맨", "타임키퍼", "타임키퍼"));
+
+        // then
+        assertThat(role.getRoleNames().getValues()).containsExactly(
+                new RoleName("카메라맨"),
+                new RoleName("타임키퍼"),
+                new RoleName("타임키퍼")
+        );
+    }
+
+    @Test
+    void 역할을_매칭한다() {
         // given
         Role role = new Role("TestTeam");
         role.updateNames(List.of("데일리 마스터", "서기"));
@@ -56,10 +71,35 @@ class RoleTest {
                         LocalDateTime.now(),
                         new TemporalUnitWithinOffset(1, ChronoUnit.SECONDS)
                 ),
-                () -> assertThat(actual.getMatchResult()).hasSize(2),
-                () -> assertThat(actual.getMatchResult()).isEqualTo(Map.of(
-                        new RoleName("데일리 마스터"), 1L,
-                        new RoleName("서기"), 2L)
+                () -> assertThat(actual.getMatchResults()).hasSize(2),
+                () -> assertThat(actual.getMatchResults()).isEqualTo(List.of(
+                        new RoleMatchResult(new RoleName("데일리 마스터"), 1L),
+                        new RoleMatchResult(new RoleName("서기"), 2L))
+                )
+        );
+    }
+
+    @Test
+    void 중복된_역할이_있을_때_역할을_매칭한다() {
+        // given
+        Role role = new Role("TestTeam");
+        role.updateNames(List.of("데일리 마스터", "서기", "서기"));
+        List<Long> memberIds = Arrays.asList(1L, 2L, 3L);
+
+        // when
+        RoleHistory actual = role.matchMembers(memberIds, ids -> {});
+
+        // then
+        Assertions.assertAll(
+                () -> assertThat(actual.getDateTime()).isCloseTo(
+                        LocalDateTime.now(),
+                        new TemporalUnitWithinOffset(1, ChronoUnit.SECONDS)
+                ),
+                () -> assertThat(actual.getMatchResults()).hasSize(3),
+                () -> assertThat(actual.getMatchResults()).isEqualTo(List.of(
+                        new RoleMatchResult(new RoleName("데일리 마스터"), 1L),
+                        new RoleMatchResult(new RoleName("서기"), 2L),
+                        new RoleMatchResult(new RoleName("서기"), 3L))
                 )
         );
     }

--- a/backend/src/test/java/com/morak/back/role/domain/RoleTest.java
+++ b/backend/src/test/java/com/morak/back/role/domain/RoleTest.java
@@ -72,10 +72,10 @@ class RoleTest {
                         new TemporalUnitWithinOffset(1, ChronoUnit.SECONDS)
                 ),
                 () -> assertThat(actual.getMatchResults()).hasSize(2),
-                () -> assertThat(actual.getMatchResults()).isEqualTo(List.of(
-                        new RoleMatchResult(new RoleName("데일리 마스터"), 1L),
-                        new RoleMatchResult(new RoleName("서기"), 2L))
-                )
+                () -> assertThat(actual.getMatchResults().get(0).getRoleName()).isEqualTo(new RoleName("데일리 마스터")),
+                () -> assertThat(actual.getMatchResults().get(0).getMemberId()).isEqualTo(1L),
+                () -> assertThat(actual.getMatchResults().get(1).getRoleName()).isEqualTo(new RoleName("서기")),
+                () -> assertThat(actual.getMatchResults().get(1).getMemberId()).isEqualTo(2L)
         );
     }
 
@@ -96,11 +96,12 @@ class RoleTest {
                         new TemporalUnitWithinOffset(1, ChronoUnit.SECONDS)
                 ),
                 () -> assertThat(actual.getMatchResults()).hasSize(3),
-                () -> assertThat(actual.getMatchResults()).isEqualTo(List.of(
-                        new RoleMatchResult(new RoleName("데일리 마스터"), 1L),
-                        new RoleMatchResult(new RoleName("서기"), 2L),
-                        new RoleMatchResult(new RoleName("서기"), 3L))
-                )
+                () -> assertThat(actual.getMatchResults().get(0).getRoleName()).isEqualTo(new RoleName("데일리 마스터")),
+                () -> assertThat(actual.getMatchResults().get(0).getMemberId()).isEqualTo(1L),
+                () -> assertThat(actual.getMatchResults().get(1).getRoleName()).isEqualTo(new RoleName("서기")),
+                () -> assertThat(actual.getMatchResults().get(1).getMemberId()).isEqualTo(2L),
+                () -> assertThat(actual.getMatchResults().get(2).getRoleName()).isEqualTo(new RoleName("서기")),
+                () -> assertThat(actual.getMatchResults().get(2).getMemberId()).isEqualTo(3L)
         );
     }
 

--- a/backend/src/test/java/com/morak/back/role/ui/RoleControllerTest.java
+++ b/backend/src/test/java/com/morak/back/role/ui/RoleControllerTest.java
@@ -35,6 +35,7 @@ import org.springframework.test.web.servlet.ResultActions;
 class RoleControllerTest extends ControllerTest {
 
     private final String groupCode = "rlgHKPj3";
+
     @MockBean
     private RoleService roleService;
 
@@ -79,9 +80,8 @@ class RoleControllerTest extends ControllerTest {
     @Test
     void 역할을_정한다() throws Exception {
         // given
-        String groupCode = "rlgHKPj3";
         Long roleId = 1L;
-        given(roleService.match(anyString(), anyLong())).willReturn(roleId);
+        given(roleService.matchRoleAndMember(anyString(), anyLong())).willReturn(roleId);
 
         // when
         ResultActions response = mockMvc.perform(post("/api/groups/{groupCode}/roles", groupCode)
@@ -101,16 +101,17 @@ class RoleControllerTest extends ControllerTest {
     @Test
     void 역할_히스토리를_조회한다() throws Exception {
         // given
-        String groupCode = "rlgHKPj3";
-        Long roleId = 1L;
         RoleResponse 서기 = new RoleResponse(1L, "서기");
         RoleResponse 카메라맨 = new RoleResponse(2L, "카메라맨");
-        HistoryResponse historyResponse1 = new HistoryResponse(LocalDate.of(2022, 10, 15), List.of(서기, 카메라맨));
-        HistoryResponse historyResponse2 = new HistoryResponse(LocalDate.of(2022, 10, 14), List.of(서기, 카메라맨));
-        RolesResponse roleResponse = new RolesResponse(
-                List.of(historyResponse1, historyResponse2
-                )
+        HistoryResponse historyResponse1 = new HistoryResponse(
+                LocalDate.of(2022, 10, 15),
+                List.of(서기, 카메라맨)
         );
+        HistoryResponse historyResponse2 = new HistoryResponse(
+                LocalDate.of(2022, 10, 14),
+                List.of(서기, 카메라맨)
+        );
+        RolesResponse roleResponse = new RolesResponse(List.of(historyResponse1, historyResponse2));
         given(roleService.findHistories(anyString(), anyLong())).willReturn(roleResponse);
 
         // when
@@ -126,5 +127,4 @@ class RoleControllerTest extends ControllerTest {
                         pathParameters(parameterWithName("groupCode").description("그룹_코드"))
                 ));
     }
-
 }

--- a/backend/src/test/resources/data.sql
+++ b/backend/src/test/resources/data.sql
@@ -58,12 +58,3 @@ VALUES (1, 2, '발표 준비 날짜 정하기', '데모 데이 발표 준비를 
         'FEsd23C1', '2022-07-31T23:59:00', now(), now());
 
 INSERT INTO slack_webhook (team_id, url, created_at, updated_at) VALUES (1L, 'https://slack.webhook.com/', now(), now());
-
-INSERT INTO role (team_code) VALUES ('MoraK123');
-
-INSERT INTO role_name (role_id, role_name) VALUES (1, '데일리 마스터');
-INSERT INTO role_name (role_id, role_name) VALUES (1, '반장');
-INSERT INTO role_name (role_id, role_name) VALUES (1, '청소부');
-
--- temp
-

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -167,7 +167,7 @@ CREATE TABLE role_match_result
     `role_history_id` BIGINT       NOT NULL,
     `member_id`       BIGINT       NOT NULL,
     `role_name`       VARCHAR(255) NOT NULL,
-    PRIMARY KEY (`role_history_id`, `role_name`)
+    PRIMARY KEY (`role_history_id`, `member_id`, `role_name`)
 );
 
 CREATE TABLE role_name

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -173,7 +173,7 @@ CREATE TABLE role_match_result
 CREATE TABLE role_name
 (
     `role_id`   BIGINT       NOT NULL,
-    `role_name` VARCHAR(255) NOT NULL
+    `name` VARCHAR(255) NOT NULL
 );
 
 CREATE TABLE role_history


### PR DESCRIPTION
## 상세 내용

Close #477 

역할 도메인을 전체적으로 살펴보면서 살짝씩 리팩토링을 진행한 후, 
`역할이 중복되었을 때 역할 수정은 가능하지만, 역할 정하기 기능은 동작하지 않았던 버그`를 수정했습니다. 
그 과정에서 예상치 못한 에러들을 몇개 마주했는데 조금 야매로 해결한 것 같아 회의가 필요합니다. 
관련 내용은 [노션](https://www.notion.so/ririhan/role-cb645c86a57d4e17bdde49108070ab57)에 정리했습니다. 

### 성능 테스트

PerformanceMonitor를 이용해 성능을 측정해보았습니다. 개선이 필요합니다. 👉 [관련 PR](https://github.com/woowacourse-teams/2022-mo-rak/pull/486)

```
2022-10-20 02:41:34 INFO  [역할 성능 테스트]
2022-10-20 02:41:34 WARN  uri: '/api/groups/code1/roles/names', method: 'GET', 요청 처리 시간: 62.285625 ms, 쿼리 개수: 5, 쿼리 시간: 4.199125 ms
2022-10-20 02:41:34 WARN  uri: '/api/groups/code1/roles/names', method: 'PUT', 요청 처리 시간: 32.944042 ms, 쿼리 개수: 9, 쿼리 시간: 2.104749 ms
2022-10-20 02:41:35 WARN  uri: '/api/groups/code1/roles', method: 'POST', 요청 처리 시간: 974.007042 ms, 쿼리 개수: 12, 쿼리 시간: 19.226043 ms
2022-10-20 02:41:38 WARN  uri: '/api/groups/code1/roles/histories', method: 'GET', 요청 처리 시간: 2218.890459 ms, 쿼리 개수: 16, 쿼리 시간: 370.448166 ms
```

![image](https://user-images.githubusercontent.com/45311765/196695123-54faf288-3d6c-4949-a67b-2aaf6ef2d5ab.png)
