### PR TITLE
feat: 역할 정하기 API에 대한 성능 테스트 추가

### DIFF
--- a/backend/src/test/java/com/morak/back/performance/PerformanceTest.java
+++ b/backend/src/test/java/com/morak/back/performance/PerformanceTest.java
@@ -31,6 +31,10 @@ import static com.morak.back.performance.support.PollRequestSupport.투표_삭�
 import static com.morak.back.performance.support.PollRequestSupport.투표_생성_요청_후_위치를_가져온다;
 import static com.morak.back.performance.support.PollRequestSupport.투표_선택항목_조회_요청_후_바디를_가져온다;
 import static com.morak.back.performance.support.PollRequestSupport.투표_진행을_요청한다;
+import static com.morak.back.performance.support.RoleRequestSupport.역할_매칭을_요청한다;
+import static com.morak.back.performance.support.RoleRequestSupport.역할_이름_목록_수정을_요청한다;
+import static com.morak.back.performance.support.RoleRequestSupport.역할_이름_목록_조회를_요청한다;
+import static com.morak.back.performance.support.RoleRequestSupport.역할_히스토를_조회를_요청한다;
 import static com.morak.back.performance.support.TeamMemberRequestSupport.extractTeamCodeFromLocation;
 import static com.morak.back.performance.support.TeamMemberRequestSupport.그룹_멤버_목록_조회를_요청한다;
 import static com.morak.back.performance.support.TeamMemberRequestSupport.그룹_목록_조회를_요청한다;
@@ -44,9 +48,11 @@ import static com.morak.back.performance.support.TeamMemberRequestSupport.기본
 import com.morak.back.auth.application.TokenProvider;
 import com.morak.back.performance.support.AppointmentDummySupport;
 import com.morak.back.performance.support.PollDummySupport;
+import com.morak.back.performance.support.RoleDummySupport;
 import com.morak.back.performance.support.TeamMemberDummySupport;
 import com.morak.back.poll.ui.dto.PollItemResponse;
 import com.morak.back.poll.ui.dto.PollResultRequest;
+import com.morak.back.role.application.dto.RoleNameEditRequest;
 import io.restassured.RestAssured;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -79,6 +85,9 @@ public class PerformanceTest {
     @Autowired
     private PollDummySupport pollDummySupport;
 
+    @Autowired
+    private RoleDummySupport roleDummySupport;
+
     @LocalServerPort
     int port;
 
@@ -101,6 +110,7 @@ public class PerformanceTest {
         팀_멤버_API의_성능을_테스트한다();
         약속잡기_API의_성능을_테스트한다();
         투표_API의_성능을_테스트한다();
+        역할_API의_성능을_테스트한다();
     }
 
     private void 더미데이터를_추가한다() {
@@ -117,6 +127,10 @@ public class PerformanceTest {
         pollDummySupport.투표_더미데이터를_추가한다(TEAM_SIZE, POLL_SIZE_PER_TEAM);
         pollDummySupport.투표_선택항목_더미데이터를_추가한다(POLL_SIZE, POLL_ITEM_SIZE_PER_POLL);
         pollDummySupport.투표_선택결과_더미데이터를_추가한다(POLL_ITEM_SIZE);
+
+        roleDummySupport.역할_더미데이터를_추가한다(List.of("code1"));
+        roleDummySupport.역할_이름_더미데이터를_추가한다();
+        roleDummySupport.역할_히스토리_더미데이터를_추가한다();
 
         double timeOfInsultDummies = (System.currentTimeMillis() - startTime) / 1_000.0;
         LOG.info(String.format("더미 데이터 추가 시간: %f", timeOfInsultDummies));
@@ -166,5 +180,14 @@ public class PerformanceTest {
         return pollItemResponses.stream()
                 .map(response -> 투표_결과_요청_데이터(response.getId()))
                 .collect(Collectors.toList());
+    }
+
+    private void 역할_API의_성능을_테스트한다() {
+        LOG.info("[역할 성능 테스트]");
+        역할_이름_목록_조회를_요청한다(TEAM_ID1_LOCATION, member1Token); // 쿼리 개수 상 문제 없음(조회라 인덱스 봐야함)
+        RoleNameEditRequest request = new RoleNameEditRequest(List.of("서기", "타임키퍼", "데일리 마스터", "데일리 마스터"));
+        역할_이름_목록_수정을_요청한다(TEAM_ID1_LOCATION, member1Token, request); // 쿼리 개수 문제 있음(insert, delete)
+        역할_매칭을_요청한다(TEAM_ID1_LOCATION, member1Token);
+        역할_히스토를_조회를_요청한다(TEAM_ID1_LOCATION, member1Token);
     }
 }

--- a/backend/src/test/java/com/morak/back/performance/dao/RoleDao.java
+++ b/backend/src/test/java/com/morak/back/performance/dao/RoleDao.java
@@ -1,0 +1,96 @@
+package com.morak.back.performance.dao;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map.Entry;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("performance")
+public class RoleDao {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public RoleDao(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public void batchInsertRoles(List<String> teamCodes) {
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO role (team_code) VALUES (?);",
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, teamCodes.get(i));
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return teamCodes.size();
+                    }
+                }
+        );
+    }
+
+    public void batchInsertRoleNames(List<Entry<Long, String>> roleNames) {
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO role_name (role_id, role_name) VALUES (?, ?)",
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        Entry<Long, String> roleName = roleNames.get(i);
+                        ps.setLong(1, roleName.getKey());
+                        ps.setString(2, roleName.getValue());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return roleNames.size();
+                    }
+                }
+        );
+    }
+
+    public void batchInsertRoleHistories(long roleId, List<LocalDateTime> dateTimes) {
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO role_history (date_time, role_id) VALUES (?, ?)",
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setObject(1, dateTimes.get(i));
+                        ps.setLong(2, roleId);
+                        batchInsertRoleMatchResult(i);
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return dateTimes.size();
+                    }
+                }
+        );
+    }
+
+    private void batchInsertRoleMatchResult(long roleHistoryId) {
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO role_match_result (role_history_id, member_id, role_name) VALUES (?, ?, ?)",
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setLong(1, roleHistoryId);
+                        ps.setLong(2, i);
+                        ps.setString(3, "데일리 마스터");
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return 3;
+                    }
+                }
+        );
+    }
+}

--- a/backend/src/test/java/com/morak/back/performance/support/RoleDummySupport.java
+++ b/backend/src/test/java/com/morak/back/performance/support/RoleDummySupport.java
@@ -1,0 +1,39 @@
+package com.morak.back.performance.support;
+
+import com.morak.back.performance.dao.RoleDao;
+import java.time.LocalDateTime;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("performance")
+public class RoleDummySupport {
+
+    @Autowired
+    private RoleDao roleDao;
+
+    public void 역할_더미데이터를_추가한다(List<String> teamCodes) {
+        roleDao.batchInsertRoles(teamCodes);
+    }
+
+    public void 역할_이름_더미데이터를_추가한다() {
+        // 1번 role에 4개의 역할 이름을 추가한다.
+        List<Entry<Long, String>> roleNames = IntStream.rangeClosed(1, 3)
+                .mapToObj(idx -> new SimpleEntry<Long, String>(1L, "데일리 마스터"))
+                .collect(Collectors.toList());
+        roleDao.batchInsertRoleNames(roleNames);
+    }
+
+    public void 역할_히스토리_더미데이터를_추가한다() {
+        List<LocalDateTime> dateTimes = IntStream.rangeClosed(0, 10_000)
+                .mapToObj(idx -> LocalDateTime.now().minusDays(idx))
+                .collect(Collectors.toList());
+        roleDao.batchInsertRoleHistories(1L, dateTimes);
+    }
+}

--- a/backend/src/test/java/com/morak/back/performance/support/RoleRequestSupport.java
+++ b/backend/src/test/java/com/morak/back/performance/support/RoleRequestSupport.java
@@ -1,0 +1,29 @@
+package com.morak.back.performance.support;
+
+import static com.morak.back.AuthSupporter.toHeader;
+import static com.morak.back.SimpleRestAssured.get;
+import static com.morak.back.SimpleRestAssured.post;
+import static com.morak.back.SimpleRestAssured.put;
+
+import com.morak.back.role.application.dto.RoleNameEditRequest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class RoleRequestSupport {
+
+    public static ExtractableResponse<Response> 역할_이름_목록_조회를_요청한다(String teamLocation, String token) {
+        return get(teamLocation + "/roles/names", toHeader(token));
+    }
+
+    public static ExtractableResponse<Response> 역할_이름_목록_수정을_요청한다(String teamLocation, String token, RoleNameEditRequest request) {
+        return put(teamLocation + "/roles/names", request, toHeader(token));
+    }
+
+    public static ExtractableResponse<Response> 역할_매칭을_요청한다(String teamLocation, String token) {
+        return post(teamLocation + "/roles", toHeader(token));
+    }
+
+    public static ExtractableResponse<Response> 역할_히스토를_조회를_요청한다(String teamLocation, String token) {
+        return get(teamLocation + "/roles/histories", toHeader(token));
+    }
+}


### PR DESCRIPTION
## 상세 내용

Close #485 

제곧내

[해당 PR 코드](https://github.com/woowacourse-teams/2022-mo-rak/pull/482)를 베이스로 성능 테스트를 진행했습니다. 
더미 데이터를 많이 넣지는 않았습니다. (불필요하다고 판단!) -> 팀1, 멤버3, 역할이름3, 히스토리10_000 정도입니다. 

![image](https://user-images.githubusercontent.com/45311765/196767773-b2a99004-ddd9-4a7b-b5a6-60db3689df6d.png)
