### PR TITLE
refactor: 툴팁 컴포넌트 리팩토링 

### DIFF
--- a/frontend/src/components/Tooltip/Tooltip.styles.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.styles.tsx
@@ -23,13 +23,6 @@ const StyledContentContainer = styled.div<
     width: ${width}rem;
     border-radius: 1.2rem;
     padding: 2rem;
-
-    &::after {
-      content: "";
-      position: absolute;
-      border-width: 0.8rem;
-      border-style: solid;
-    }
 `
 );
 

--- a/frontend/src/components/Tooltip/Tooltip.styles.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.styles.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 const StyledContainer = styled.div`
   position: relative;
-  z-index: 1;
 `;
 
 const StyledContentTrigger = styled.div`

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.styles.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.styles.tsx
@@ -26,4 +26,10 @@ const StyledContent = styled.p`
   font-size: 2.4rem;
 `;
 
-export { StyledTitle, StyledHelpIconContainer, StyledHelpIcon, StyledContent };
+const StyledHeader = styled.div`
+  display: flex;
+  gap: 2rem;
+  z-index: 1;
+`;
+
+export { StyledTitle, StyledHelpIconContainer, StyledHelpIcon, StyledContent, StyledHeader };

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
@@ -8,7 +8,8 @@ import {
   StyledTitle,
   StyledHelpIconContainer,
   StyledHelpIcon,
-  StyledContent
+  StyledContent,
+  StyledHeader
 } from './AppointmentCreateFormTimeLimitInput.styles';
 
 type Props = {
@@ -26,7 +27,7 @@ function AppointmentCreateFormTimeLimitInput({
 }: Props) {
   return (
     <>
-      <FlexContainer gap="2rem">
+      <StyledHeader>
         <StyledTitle>가능 시간 제한 설정</StyledTitle>
         <Tooltip
           content="오전 12:00 ~ 오전 12:00(다음날)은 하루종일을 의미합니다."
@@ -37,7 +38,7 @@ function AppointmentCreateFormTimeLimitInput({
             <StyledHelpIcon src={Question} alt="help-icon" />
           </StyledHelpIconContainer>
         </Tooltip>
-      </FlexContainer>
+      </StyledHeader>
 
       <FlexContainer alignItems="center" gap="2.8rem">
         <AppointmentCreateFormTimeInput

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
@@ -11,6 +11,7 @@ import {
   StyledContent,
   StyledHeader
 } from './AppointmentCreateFormTimeLimitInput.styles';
+import { useTheme } from '@emotion/react';
 
 type Props = {
   startTime: Time;
@@ -25,6 +26,8 @@ function AppointmentCreateFormTimeLimitInput({
   onChangeStartTime,
   onChangeEndTime
 }: Props) {
+  const theme = useTheme();
+
   return (
     <>
       <StyledHeader>
@@ -32,8 +35,9 @@ function AppointmentCreateFormTimeLimitInput({
         <Tooltip
           content="오전 12:00 ~ 오전 12:00(다음날)은 하루종일을 의미합니다."
           width="28"
-          placement="right"
+          placement="bottom"
           fontSize="1.6rem"
+          backgroundColor={theme.colors.GRAY_200}
         >
           <StyledHelpIconContainer>
             <StyledHelpIcon src={Question} alt="help-icon" />

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
@@ -35,7 +35,7 @@ function AppointmentCreateFormTimeLimitInput({
         <Tooltip
           content="오전 12:00 ~ 오전 12:00(다음날)은 하루종일을 의미합니다."
           width="28"
-          placement="bottom"
+          placement="right"
           fontSize="1.6rem"
           backgroundColor={theme.colors.GRAY_200}
         >

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
@@ -31,8 +31,9 @@ function AppointmentCreateFormTimeLimitInput({
         <StyledTitle>가능 시간 제한 설정</StyledTitle>
         <Tooltip
           content="오전 12:00 ~ 오전 12:00(다음날)은 하루종일을 의미합니다."
-          width="26"
+          width="28"
           placement="right"
+          fontSize="1.6rem"
         >
           <StyledHelpIconContainer>
             <StyledHelpIcon src={Question} alt="help-icon" />

--- a/frontend/src/pages/AppointmentResultPage/components/AppointmentResultButtonGroup/AppointmentResultButtonGroup.tsx
+++ b/frontend/src/pages/AppointmentResultPage/components/AppointmentResultButtonGroup/AppointmentResultButtonGroup.tsx
@@ -160,9 +160,10 @@ function AppointmentResultButtonGroup({
               </Button>
               <Tooltip
                 content="공동 1등이 나왔네요! 공동 1등에 대한 재투표를 생성할 수 있습니다."
-                width="24"
+                width="28"
                 placement="right"
-                backgroundColor={theme.colors.GRAY_300}
+                backgroundColor={theme.colors.GRAY_200}
+                fontSize="1.6rem"
               >
                 <StyledHelpIconContainer>
                   <StyledHelpIcon src={Question} alt="help-icon" />

--- a/frontend/src/pages/AppointmentResultPage/components/AppointmentResultHeader/AppointmentResultHeader.tsx
+++ b/frontend/src/pages/AppointmentResultPage/components/AppointmentResultHeader/AppointmentResultHeader.tsx
@@ -15,10 +15,10 @@ import {
 } from './AppointmentResultHeader.styles';
 import Tooltip from '../../../../components/Tooltip/Tooltip';
 import Question from '../../../../assets/question.svg';
+import { useTheme } from '@emotion/react';
 
 const getFormattedClosedTime = (value: string) => {
   const date = new Date(value);
-
   return date.toLocaleString('ko-KR', {
     year: 'numeric',
     month: 'long',
@@ -38,6 +38,8 @@ type Props = {
 };
 
 function AppointmentResultHeader({ groupCode, appointmentCode, title, isClosed, closedAt }: Props) {
+  const theme = useTheme();
+
   const handleCopyInvitationLink = () => {
     const baseLink = `${process.env.CLIENT_URL}/groups/${groupCode}/appointment/${appointmentCode}`;
 
@@ -74,6 +76,8 @@ function AppointmentResultHeader({ groupCode, appointmentCode, title, isClosed, 
             content="공동 1등이 나오면, 마감 이후 재투표를 빠르게 진행할 수 있어요!"
             width="28"
             placement="bottom"
+            fontSize="1.6rem"
+            backgroundColor={theme.colors.GRAY_200}
           >
             <FlexContainer gap="2rem" alignItems="center">
               <StyledDescription>공동 1등이 나오면 어떻게하나요?</StyledDescription>

--- a/frontend/src/pages/PollResultPage/components/PollResultContainer/PollResultContainer.tsx
+++ b/frontend/src/pages/PollResultPage/components/PollResultContainer/PollResultContainer.tsx
@@ -104,6 +104,7 @@ function PollResultContainer() {
                   width="32"
                   placement="bottom"
                   backgroundColor={theme.colors.PURPLE_50}
+                  fontSize="1.6rem"
                 >
                   <FlexContainer gap="1.2rem" alignItems="center">
                     <StyledHelpIconContainer>


### PR DESCRIPTION
## 상세 내용
- 툴팁 컴포넌트에 적용이 되어있는 z-index를 삭제해서, (#525) 이슈에 있는 오류를 수정했습니다. 
- 수정하면서 툴팁 `font-size`를 전체적으로 키웠습니다. (1.6rem) 
- 말풍선 꼬리가 불필요하다고 판단되어서 삭제했습니다. 
<img width="530" alt="스크린샷 2022-10-27 오후 2 44 20" src="https://user-images.githubusercontent.com/52344833/198201485-77a69e8f-b4b8-45b1-97dd-ecf69c10d56f.png">
기존에 말풍선 꼬리가 위치를 제대로 잡아주지 않고 있었는데, 제대로 위치를 잡도록 하기 위해서는 꽤 복잡한 작업이 필요했습니다. 😅 
복잡한 작업에 비해 중요도가 높지 않다고 생각되어서, 말풍선 꼬리는 삭제해주었습니다. 

Close #525

