### PR TITLE
feat: 약속 진행시간 header 추가 및 수정 

### DIFF
--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.tsx
@@ -125,7 +125,7 @@ function AppointmentCreateForm({ startDate, endDate }: Props) {
     // TODO: StyledForm처럼 컴포넌트의 역할을 담은 네이밍을 해줄 것인지? S
     // StyledContainer처럼 최상단은 무조건 StyledContainer로 해줄 것인지 컨벤션 정해서 통일
     <StyledForm onSubmit={handleCreateAppointment}>
-      <Box width="66rem" padding="5.2rem">
+      <Box width="66rem" padding="4.8rem" height="60rem">
         <FlexContainer flexDirection="column" gap="2rem">
           <AppointmentCreateFormTitleInput title={title} onChange={handleTitle} />
           <AppointmentCreateFormDescriptionInput

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormDurationInput/AppointmentCreateFormDurationInput.styles.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormDurationInput/AppointmentCreateFormDurationInput.styles.tsx
@@ -1,5 +1,12 @@
 import styled from '@emotion/styled';
 
+const StyledTitle = styled.div(
+  ({ theme }) => `
+  font-size: 2.8rem;
+  color: ${theme.colors.PURPLE_100};
+`
+);
+
 const StyledContent = styled.p`
   font-size: 2.8rem;
 `;
@@ -8,4 +15,4 @@ const StyledLabel = styled.label`
   font-size: 2.8rem;
 `;
 
-export { StyledContent, StyledLabel };
+export { StyledTitle, StyledContent, StyledLabel };

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormDurationInput/AppointmentCreateFormDurationInput.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormDurationInput/AppointmentCreateFormDurationInput.tsx
@@ -5,7 +5,11 @@ import TextField from '../../../../components/TextField/TextField';
 import Select from '../../../../components/Select/Select';
 import { createRange } from '../../../../utils/createRange';
 import { Time } from '../../../../types/appointment';
-import { StyledContent, StyledLabel } from './AppointmentCreateFormDurationInput.styles';
+import {
+  StyledTitle,
+  StyledContent,
+  StyledLabel
+} from './AppointmentCreateFormDurationInput.styles';
 
 type Props = {
   duration: Omit<Time, 'period'>;
@@ -16,56 +20,59 @@ function AppointmentCreateFormDurationInput({ duration, onChange }: Props) {
   const { hour, minute } = duration;
 
   return (
-    <FlexContainer alignItems="end" gap="1.2rem">
-      <TextField
-        variant="outlined"
-        colorScheme={theme.colors.PURPLE_100}
-        borderRadius="1.2rem"
-        padding="0.4rem 0.8rem"
-        width="6rem"
-      >
-        <Select
-          id="hour"
-          onChange={onChange}
-          value={hour}
-          name="hour"
-          aria-label="appointment-duration-hour"
-          required
+    <>
+      <StyledTitle>진행 시간 설정</StyledTitle>
+      <FlexContainer alignItems="end" gap="1.2rem">
+        <TextField
+          variant="outlined"
+          colorScheme={theme.colors.PURPLE_100}
+          borderRadius="1.2rem"
+          padding="0.4rem 0.8rem"
+          width="6rem"
         >
-          <option value="">--</option>
-          {createRange({
-            size: 25
-          }).map((hour: number) => (
-            <option key={hour} value={hour}>
-              {hour}
-            </option>
-          ))}
-        </Select>
-      </TextField>
-      <StyledLabel htmlFor="hour">시간</StyledLabel>
-      <TextField
-        variant="outlined"
-        colorScheme={theme.colors.PURPLE_100}
-        borderRadius="1.2rem"
-        padding="0.4rem 0.8rem"
-        width="9.2rem"
-      >
-        <Select
-          id="minute"
-          onChange={onChange}
-          value={minute}
-          name="minute"
-          fontSize="2.4rem"
-          aria-label="appointment-duration-minute"
-          required
+          <Select
+            id="hour"
+            onChange={onChange}
+            value={hour}
+            name="hour"
+            aria-label="appointment-duration-hour"
+            required
+          >
+            <option value="">--</option>
+            {createRange({
+              size: 25
+            }).map((hour: number) => (
+              <option key={hour} value={hour}>
+                {hour}
+              </option>
+            ))}
+          </Select>
+        </TextField>
+        <StyledLabel htmlFor="hour">시간</StyledLabel>
+        <TextField
+          variant="outlined"
+          colorScheme={theme.colors.PURPLE_100}
+          borderRadius="1.2rem"
+          padding="0.4rem 0.8rem"
+          width="9.2rem"
         >
-          <option value="00">00</option>
-          <option value="30">30</option>
-        </Select>
-      </TextField>
-      <StyledLabel htmlFor="minute">분</StyledLabel>
-      <StyledContent>동안 진행</StyledContent>
-    </FlexContainer>
+          <Select
+            id="minute"
+            onChange={onChange}
+            value={minute}
+            name="minute"
+            fontSize="2.4rem"
+            aria-label="appointment-duration-minute"
+            required
+          >
+            <option value="00">00</option>
+            <option value="30">30</option>
+          </Select>
+        </TextField>
+        <StyledLabel htmlFor="minute">분</StyledLabel>
+        <StyledContent>동안 진행</StyledContent>
+      </FlexContainer>
+    </>
   );
 }
 

--- a/frontend/src/pages/AppointmentProgressPage/components/AppointmentProgressDetail/AppointmentProgressDetail.tsx
+++ b/frontend/src/pages/AppointmentProgressPage/components/AppointmentProgressDetail/AppointmentProgressDetail.tsx
@@ -12,7 +12,7 @@ type Props = {
 function AppointmentProgressDetail({ durationHours, durationMinutes, startTime, endTime }: Props) {
   return (
     <StyledDuration>
-      약속 진행시간: {getFormattedHourMinuteDuration(durationHours, durationMinutes)} ({startTime}~
+      진행 시간: {getFormattedHourMinuteDuration(durationHours, durationMinutes)} ({startTime}~
       {endTime})
     </StyledDuration>
   );


### PR DESCRIPTION
하이 앨버~🐝 이야기했던대로 약속 진행시간에 대한 header를 추가해주고, 수정해주었습니다. 

## 상세 내용
- `약속 생성 페이지`
  진행 시간 설정에 대한 header를 추가했습니다. 
요기서 캘린더와 height를 맞추어주기 위해, 오른쪽 박스에도 캘린더에도 적용되어있는 height를 동일하게 주었는데요, 괜찮은지 의견주세요! 👀 (padding으로 하기에는 너무 눈대중이여서, 캘린더와 동일한 height를 주는 것이 정확하다고 생각했습니다!) 
  <img width="973" alt="스크린샷 2022-10-27 오후 7 20 20" src="https://user-images.githubusercontent.com/52344833/198259665-8113db4c-8d80-419d-932d-c1782f95bba3.png">

- `약속 진행 페이지`
  약속 진행 시간 -> 진행 시간으로 수정했습니다. 
  <img width="676" alt="스크린샷 2022-10-27 오후 7 21 01" src="https://user-images.githubusercontent.com/52344833/198259800-b72b3603-2740-4067-a9e9-d2c983f4c081.png">


Close #527
