### PR TITLE
refactor: 투표 쿼리 성능 개선

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,7 +29,6 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-//    implementation 'org.projectlombok:lombok:1.18.20'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.github.maricn:logback-slack-appender:1.6.1'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,7 +29,7 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.projectlombok:lombok:1.18.20'
+//    implementation 'org.projectlombok:lombok:1.18.20'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.github.maricn:logback-slack-appender:1.6.1'
@@ -62,6 +62,10 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
 
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // for using lombok in test package
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/morak/back/poll/application/PollService.java
+++ b/backend/src/main/java/com/morak/back/poll/application/PollService.java
@@ -10,7 +10,6 @@ import com.morak.back.poll.application.dto.PollItemResultResponse;
 import com.morak.back.poll.application.dto.PollResponse;
 import com.morak.back.poll.application.dto.PollResultRequest;
 import com.morak.back.poll.domain.Poll;
-import com.morak.back.poll.domain.PollItem;
 import com.morak.back.poll.domain.PollRepository;
 import com.morak.back.poll.exception.PollAuthorizationException;
 import com.morak.back.poll.exception.PollNotFoundException;
@@ -132,9 +131,7 @@ public class PollService {
     public List<PollItemResponse> findPollItems(String teamCode, Long memberId, String pollCode) {
         return authorizationService.withTeamMemberValidation(
                 () -> {
-                    Poll poll = pollRepository.findFetchedByCode(pollCode).orElseThrow(
-                            () -> PollNotFoundException.of(CustomErrorCode.POLL_NOT_FOUND_ERROR, pollCode)
-                    );
+                    Poll poll = findPollInTeam(teamCode, pollCode);
                     validatePollInTeam(teamCode, poll);
 
                     return poll.getPollItems()

--- a/backend/src/main/java/com/morak/back/poll/application/PollService.java
+++ b/backend/src/main/java/com/morak/back/poll/application/PollService.java
@@ -59,9 +59,9 @@ public class PollService {
         );
     }
 
-    private Map<PollItem, String> toDataOfSelected(List<PollResultRequest> requests) {
+    private Map<Long, String> toDataOfSelected(List<PollResultRequest> requests) {
         return requests.stream()
-                .collect(Collectors.toMap(PollResultRequest::toPollItem, PollResultRequest::getDescription));
+                .collect(Collectors.toMap(PollResultRequest::getId, PollResultRequest::getDescription));
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/morak/back/poll/application/dto/PollResponse.java
+++ b/backend/src/main/java/com/morak/back/poll/application/dto/PollResponse.java
@@ -2,11 +2,8 @@ package com.morak.back.poll.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.morak.back.poll.domain.Poll;
-import com.morak.back.poll.domain.PollItem;
 import com.morak.back.poll.domain.PollStatus;
 import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -49,16 +46,8 @@ public class PollResponse implements Comparable<PollResponse> {
                 poll.getClosedAt(),
                 poll.getCode(),
                 poll.isHost(memberId),
-                countSelectMembers(poll.getPollItems())
+                poll.getCount()
         );
-    }
-
-    private static int countSelectMembers(List<PollItem> pollItems) {
-        return (int) pollItems.stream()
-                .map(PollItem::getOnlyMembers)
-                .flatMap(Collection::stream)
-                .distinct()
-                .count();
     }
 
     @Override

--- a/backend/src/main/java/com/morak/back/poll/application/dto/PollResponse.java
+++ b/backend/src/main/java/com/morak/back/poll/application/dto/PollResponse.java
@@ -46,7 +46,7 @@ public class PollResponse implements Comparable<PollResponse> {
                 poll.getClosedAt(),
                 poll.getCode(),
                 poll.isHost(memberId),
-                poll.getCount()
+                poll.getSelectedCount()
         );
     }
 

--- a/backend/src/main/java/com/morak/back/poll/domain/AllowedCount.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/AllowedCount.java
@@ -35,7 +35,7 @@ public class AllowedCount {
         return this.value > itemCount;
     }
 
-    public boolean isGreaterThanOrEqual(int itemCount) {
-        return this.value >= itemCount;
+    public boolean isLessThan(int itemCount) {
+        return this.value < itemCount;
     }
 }

--- a/backend/src/main/java/com/morak/back/poll/domain/Poll.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/Poll.java
@@ -32,9 +32,6 @@ public class Poll extends BaseRootEntity<Poll> {
     @Column(nullable = false)
     private boolean anonymous;
 
-    @Column(nullable = false)
-    private int selectedCount;
-
     @Builder
     public Poll(Code teamCode, Long hostId, Code code, String title, MenuStatus status, ClosedAt closedAt,
                 List<PollItem> pollItems, int allowedCount, boolean anonymous) {
@@ -60,7 +57,6 @@ public class Poll extends BaseRootEntity<Poll> {
         this.menu = menu;
         this.pollItems = pollItems;
         this.anonymous = anonymous;
-        this.selectedCount = pollItems.countSelectMembers();
         registerEvent(PollEvent.from(menu));
     }
 
@@ -68,7 +64,6 @@ public class Poll extends BaseRootEntity<Poll> {
         validateStatusOpen();
 
         pollItems.doPoll(memberId, data);
-        selectedCount = pollItems.countSelectMembers();
     }
 
     private void validateStatusOpen() {
@@ -127,5 +122,9 @@ public class Poll extends BaseRootEntity<Poll> {
 
     public String getStatus() {
         return this.menu.getStatus();
+    }
+
+    public int getSelectedCount() {
+        return this.pollItems.getSelectedCount();
     }
 }

--- a/backend/src/main/java/com/morak/back/poll/domain/Poll.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/Poll.java
@@ -32,6 +32,9 @@ public class Poll extends BaseRootEntity<Poll> {
     @Column(nullable = false)
     private boolean anonymous;
 
+    @Column(nullable = false)
+    private int count;
+
     @Builder
     public Poll(Code teamCode, Long hostId, Code code, String title, MenuStatus status, ClosedAt closedAt,
                 List<PollItem> pollItems, int allowedCount, boolean anonymous) {
@@ -57,6 +60,7 @@ public class Poll extends BaseRootEntity<Poll> {
         this.menu = menu;
         this.pollItems = pollItems;
         this.anonymous = anonymous;
+        this.count = pollItems.countSelectMembers();
         registerEvent(PollEvent.from(menu));
     }
 
@@ -64,6 +68,7 @@ public class Poll extends BaseRootEntity<Poll> {
         validateStatusOpen();
 
         pollItems.doPoll(memberId, data);
+        count = pollItems.countSelectMembers();
     }
 
     private void validateStatusOpen() {

--- a/backend/src/main/java/com/morak/back/poll/domain/Poll.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/Poll.java
@@ -8,12 +8,9 @@ import com.morak.back.core.domain.menu.MenuStatus;
 import com.morak.back.core.domain.menu.Title;
 import com.morak.back.core.exception.CustomErrorCode;
 import com.morak.back.poll.exception.PollDomainLogicException;
-import com.morak.back.poll.exception.PollItemNotFoundException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -63,10 +60,8 @@ public class Poll extends BaseRootEntity<Poll> {
         registerEvent(PollEvent.from(menu));
     }
 
-    public void doPoll(Long memberId, Map<PollItem, String> data) {
+    public void doPoll(Long memberId, Map<Long, String> data) {
         validateStatusOpen();
-        validateExistItem(data.keySet());
-        validatePollCountAllowed(data.size());
 
         pollItems.doPoll(memberId, data);
     }
@@ -76,26 +71,6 @@ public class Poll extends BaseRootEntity<Poll> {
             throw new PollDomainLogicException(
                     CustomErrorCode.POLL_ALREADY_CLOSED_ERROR,
                     menu.getCode() + " 코드의 투표는 종료되었습니다."
-            );
-        }
-    }
-
-    private void validateExistItem(Set<PollItem> selectItems) {
-        if (!pollItems.containsAll(selectItems)) {
-            throw new PollItemNotFoundException(
-                    CustomErrorCode.POLL_ITEM_NOT_FOUND_ERROR,
-                    id + "번 투표에 " +
-                            pollItems.getValues().stream()
-                                    .map(pollItem -> pollItem.getId().toString())
-                                    .collect(Collectors.joining(", ")) + "번 항목들은 투표할 수 없습니다.");
-        }
-    }
-
-    private void validatePollCountAllowed(int itemCount) {
-        if (!pollItems.isPollCountAllowed(itemCount)) {
-            throw new PollDomainLogicException(
-                    CustomErrorCode.POLL_COUNT_OUT_OF_RANGE_ERROR,
-                    this.id + "번 투표에 " + getAllowedCount().getValue() + "개 보다 많은(" + itemCount + ") 투표 항목을 선택할 수 없습니다."
             );
         }
     }

--- a/backend/src/main/java/com/morak/back/poll/domain/Poll.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/Poll.java
@@ -33,7 +33,7 @@ public class Poll extends BaseRootEntity<Poll> {
     private boolean anonymous;
 
     @Column(nullable = false)
-    private int count;
+    private int selectedCount;
 
     @Builder
     public Poll(Code teamCode, Long hostId, Code code, String title, MenuStatus status, ClosedAt closedAt,
@@ -60,7 +60,7 @@ public class Poll extends BaseRootEntity<Poll> {
         this.menu = menu;
         this.pollItems = pollItems;
         this.anonymous = anonymous;
-        this.count = pollItems.countSelectMembers();
+        this.selectedCount = pollItems.countSelectMembers();
         registerEvent(PollEvent.from(menu));
     }
 
@@ -68,7 +68,7 @@ public class Poll extends BaseRootEntity<Poll> {
         validateStatusOpen();
 
         pollItems.doPoll(memberId, data);
-        count = pollItems.countSelectMembers();
+        selectedCount = pollItems.countSelectMembers();
     }
 
     private void validateStatusOpen() {

--- a/backend/src/main/java/com/morak/back/poll/domain/PollItems.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/PollItems.java
@@ -4,6 +4,7 @@ import com.morak.back.core.exception.CustomErrorCode;
 import com.morak.back.poll.exception.PollDomainLogicException;
 import com.morak.back.poll.exception.PollItemNotFoundException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -83,5 +84,13 @@ public class PollItems {
             return;
         }
         pollItem.remove(memberId);
+    }
+
+    public int countSelectMembers() {
+        return (int) values.stream()
+                .map(PollItem::getOnlyMembers)
+                .flatMap(Collection::stream)
+                .distinct()
+                .count();
     }
 }

--- a/backend/src/main/java/com/morak/back/poll/domain/PollItems.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/PollItems.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
 import javax.persistence.JoinColumn;
@@ -31,11 +32,15 @@ public class PollItems {
     @Embedded
     private AllowedCount allowedCount;
 
+    @Column(nullable = false)
+    private int selectedCount;
+
     @Builder
     public PollItems(List<PollItem> values, AllowedCount allowedCount) {
         validateCountAllowed(values, allowedCount);
         this.values = new ArrayList<>(values);
         this.allowedCount = allowedCount;
+        updateSelectedCount();
     }
 
     private void validateCountAllowed(List<PollItem> values, AllowedCount allowedCount) {
@@ -54,6 +59,7 @@ public class PollItems {
         for (PollItem pollItem : values) {
             addOrRemove(pollItem, memberId, data);
         }
+        updateSelectedCount();
     }
 
     private void validateExistItem(Set<Long> selectItems) {
@@ -86,8 +92,8 @@ public class PollItems {
         pollItem.remove(memberId);
     }
 
-    public int countSelectMembers() {
-        return (int) values.stream()
+    private void updateSelectedCount() {
+        this.selectedCount = (int) this.values.stream()
                 .map(PollItem::getOnlyMembers)
                 .flatMap(Collection::stream)
                 .distinct()

--- a/backend/src/main/java/com/morak/back/poll/domain/PollItems.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/PollItems.java
@@ -2,11 +2,13 @@ package com.morak.back.poll.domain;
 
 import com.morak.back.core.exception.CustomErrorCode;
 import com.morak.back.poll.exception.PollDomainLogicException;
+import com.morak.back.poll.exception.PollItemNotFoundException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
@@ -44,25 +46,42 @@ public class PollItems {
         }
     }
 
-    public void doPoll(Long memberId, Map<PollItem, String> data) {
+    public void doPoll(Long memberId, Map<Long, String> data) {
+        validateExistItem(data.keySet());
+        validatePollCountAllowed(data.size());
+
         for (PollItem pollItem : values) {
             addOrRemove(pollItem, memberId, data);
         }
     }
 
-    public boolean isPollCountAllowed(int itemCount) {
-        return itemCount >= 1 && this.allowedCount.isGreaterThanOrEqual(itemCount);
+    private void validateExistItem(Set<Long> selectItems) {
+        List<Long> pollItemIds = values.stream()
+                .map(PollItem::getId)
+                .collect(Collectors.toList());
+        if (!new HashSet<>(pollItemIds).containsAll(selectItems)) {
+            throw new PollItemNotFoundException(
+                    CustomErrorCode.POLL_ITEM_NOT_FOUND_ERROR,
+                    values.stream()
+                            .map(pollItem -> pollItem.getId().toString())
+                            .collect(Collectors.joining(", ")) + "번 항목들은 투표할 수 없습니다.");
+        }
     }
 
-    private void addOrRemove(PollItem pollItem, Long memberId, Map<PollItem, String> data) {
-        if (data.containsKey(pollItem)) {
-            pollItem.addSelectMember(memberId, data.get(pollItem));
+    private void validatePollCountAllowed(int itemCount) {
+        if (itemCount < 1 || this.allowedCount.isLessThan(itemCount)) {
+            throw new PollDomainLogicException(
+                    CustomErrorCode.POLL_COUNT_OUT_OF_RANGE_ERROR,
+                    allowedCount.getValue() + "개 보다 많은(" + itemCount + ") 투표 항목을 선택할 수 없습니다."
+            );
+        }
+    }
+
+    private void addOrRemove(PollItem pollItem, Long memberId, Map<Long, String> data) {
+        if (data.containsKey(pollItem.getId())) {
+            pollItem.addSelectMember(memberId, data.get(pollItem.getId()));
             return;
         }
         pollItem.remove(memberId);
-    }
-
-    public boolean containsAll(Collection<PollItem> items) {
-        return new HashSet<>(this.values).containsAll(items);
     }
 }

--- a/backend/src/main/java/com/morak/back/poll/domain/PollRepository.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/PollRepository.java
@@ -3,18 +3,22 @@ package com.morak.back.poll.domain;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
 
-public interface PollRepository extends JpaRepository<Poll, Long> {
+public interface PollRepository extends Repository<Poll, Long> {
 
-    @Query("select p from Poll p where p.menu.code.code = :code")
+    Poll save(Poll poll);
+
+    @Query("SELECT p FROM Poll p WHERE p.menu.code.code = :code")
     Optional<Poll> findByCode(@Param("code") String code);
 
-    @Query("select p from Poll p inner join Team t on t.code = p.menu.teamCode where p.menu.status = 'OPEN' and p.menu.closedAt.closedAt <= :thresholdDateTime")
+    @Query("SELECT p FROM Poll p INNER JOIN Team t ON t.code = p.menu.teamCode WHERE p.menu.status = 'OPEN' AND p.menu.closedAt.closedAt <= :thresholdDateTime")
     List<Poll> findAllToBeClosed(@Param("thresholdDateTime") LocalDateTime thresholdDateTime);
 
-    @Query("select p from Poll p where p.menu.teamCode.code = :teamCode")
+    @Query("SELECT p FROM Poll p WHERE p.menu.teamCode.code = :teamCode")
     List<Poll> findAllByTeamCode(@Param("teamCode") String teamCode);
+
+    void delete(Poll poll);
 }

--- a/backend/src/main/java/com/morak/back/poll/domain/PollRepository.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/PollRepository.java
@@ -12,13 +12,6 @@ public interface PollRepository extends JpaRepository<Poll, Long> {
     @Query("select p from Poll p where p.menu.code.code = :code")
     Optional<Poll> findByCode(@Param("code") String code);
 
-    @Query("select p "
-            + "from Poll p "
-            + "join fetch p.pollItems.values pi "
-            + "left join pi.selectMembers "
-            + "where p.menu.code.code = :code")
-    Optional<Poll> findFetchedByCode(@Param("code") String pollCode);
-
     @Query("select p from Poll p inner join Team t on t.code = p.menu.teamCode where p.menu.status = 'OPEN' and p.menu.closedAt.closedAt <= :thresholdDateTime")
     List<Poll> findAllToBeClosed(@Param("thresholdDateTime") LocalDateTime thresholdDateTime);
 

--- a/backend/src/main/resources/schema-dev.sql
+++ b/backend/src/main/resources/schema-dev.sql
@@ -93,6 +93,7 @@ create table select_member
 
 CREATE INDEX `poll_index_closed_at` ON `poll` (`closed_at`);
 CREATE INDEX `poll_index_code` ON `poll` (`code`);
+CREATE INDEX `poll_index_team_code` ON `poll` (`team_code`);
 
 CREATE TABLE appointment
 (

--- a/backend/src/main/resources/schema-dev.sql
+++ b/backend/src/main/resources/schema-dev.sql
@@ -72,7 +72,8 @@ CREATE TABLE poll
     selected_count INTEGER      NOT NULL DEFAULT 0,
     created_at     DATETIME     NOT NULL,
     updated_at     DATETIME     NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (team_code) REFERENCES team (code)
 );
 
 CREATE TABLE poll_item
@@ -80,7 +81,8 @@ CREATE TABLE poll_item
     id      BIGINT NOT NULL AUTO_INCREMENT,
     subject VARCHAR(255),
     poll_id BIGINT NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (poll_id) REFERENCES poll (id)
 );
 
 create table select_member
@@ -88,12 +90,13 @@ create table select_member
     poll_item_id BIGINT        NOT NULL,
     description  VARCHAR(1000) NOT NULL,
     member_id    BIGINT        NOT NULL,
-    PRIMARY KEY (poll_item_id, member_id)
+    PRIMARY KEY (poll_item_id, member_id),
+    FOREIGN KEY (poll_item_id) REFERENCES poll_item (id),
+    FOREIGN KEY (member_id) REFERENCES member (id)
 );
 
 CREATE INDEX `poll_index_closed_at` ON `poll` (`closed_at`);
 CREATE INDEX `poll_index_code` ON `poll` (`code`);
-CREATE INDEX `poll_index_team_code` ON `poll` (`team_code`);
 
 CREATE TABLE appointment
 (

--- a/backend/src/main/resources/schema-dev.sql
+++ b/backend/src/main/resources/schema-dev.sql
@@ -91,7 +91,8 @@ create table select_member
     PRIMARY KEY (poll_item_id, member_id)
 );
 
-CREATE INDEX `index_poll` ON `poll` (`closed_at`);
+CREATE INDEX `poll_index_closed_at` ON `poll` (`closed_at`);
+CREATE INDEX `poll_index_code` ON `poll` (`code`);
 
 CREATE TABLE appointment
 (

--- a/backend/src/main/resources/schema-dev.sql
+++ b/backend/src/main/resources/schema-dev.sql
@@ -60,18 +60,18 @@ CREATE TABLE team_invitation
 
 CREATE TABLE poll
 (
-    id            BIGINT       NOT NULL AUTO_INCREMENT,
-    allowed_count INT          NOT NULL,
-    anonymous     BOOLEAN      NOT NULL,
-    code          VARCHAR(255) NOT NULL,
-    host_id       BIGINT       NOT NULL,
-    status        VARCHAR(255) NOT NULL,
-    team_code     VARCHAR(255) NOT NULL,
-    title         VARCHAR(255) NOT NULL,
-    closed_at     DATETIME     NOT NULL,
-    count         INTEGER      NOT NULL DEFAULT 0,
-    created_at    DATETIME     NOT NULL,
-    updated_at    DATETIME     NOT NULL,
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    allowed_count  INT          NOT NULL,
+    anonymous      BOOLEAN      NOT NULL,
+    code           VARCHAR(255) NOT NULL,
+    host_id        BIGINT       NOT NULL,
+    status         VARCHAR(255) NOT NULL,
+    team_code      VARCHAR(255) NOT NULL,
+    title          VARCHAR(255) NOT NULL,
+    closed_at      DATETIME     NOT NULL,
+    selected_count INTEGER      NOT NULL DEFAULT 0,
+    created_at     DATETIME     NOT NULL,
+    updated_at     DATETIME     NOT NULL,
     PRIMARY KEY (id)
 );
 

--- a/backend/src/main/resources/schema-dev.sql
+++ b/backend/src/main/resources/schema-dev.sql
@@ -69,6 +69,7 @@ CREATE TABLE poll
     team_code     VARCHAR(255) NOT NULL,
     title         VARCHAR(255) NOT NULL,
     closed_at     DATETIME     NOT NULL,
+    count         INTEGER      NOT NULL DEFAULT 0,
     created_at    DATETIME     NOT NULL,
     updated_at    DATETIME     NOT NULL,
     PRIMARY KEY (id)

--- a/backend/src/main/resources/schema-local.sql
+++ b/backend/src/main/resources/schema-local.sql
@@ -93,6 +93,7 @@ create table select_member
 
 CREATE INDEX `poll_index_closed_at` ON `poll` (`closed_at`);
 CREATE INDEX `poll_index_code` ON `poll` (`code`);
+CREATE INDEX `poll_index_team_code` ON `poll` (`team_code`);
 
 CREATE TABLE appointment
 (

--- a/backend/src/main/resources/schema-local.sql
+++ b/backend/src/main/resources/schema-local.sql
@@ -72,7 +72,8 @@ CREATE TABLE poll
     selected_count INTEGER      NOT NULL DEFAULT 0,
     created_at     DATETIME     NOT NULL,
     updated_at     DATETIME     NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (team_code) REFERENCES team (code)
 );
 
 CREATE TABLE poll_item
@@ -80,7 +81,8 @@ CREATE TABLE poll_item
     id      BIGINT NOT NULL AUTO_INCREMENT,
     subject VARCHAR(255),
     poll_id BIGINT NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (poll_id) REFERENCES poll (id)
 );
 
 create table select_member
@@ -88,12 +90,13 @@ create table select_member
     poll_item_id BIGINT        NOT NULL,
     description  VARCHAR(1000) NOT NULL,
     member_id    BIGINT        NOT NULL,
-    PRIMARY KEY (poll_item_id, member_id)
+    PRIMARY KEY (poll_item_id, member_id),
+    FOREIGN KEY (poll_item_id) REFERENCES poll_item (id),
+    FOREIGN KEY (member_id) REFERENCES member (id)
 );
 
 CREATE INDEX `poll_index_closed_at` ON `poll` (`closed_at`);
 CREATE INDEX `poll_index_code` ON `poll` (`code`);
-CREATE INDEX `poll_index_team_code` ON `poll` (`team_code`);
 
 CREATE TABLE appointment
 (

--- a/backend/src/main/resources/schema-local.sql
+++ b/backend/src/main/resources/schema-local.sql
@@ -91,7 +91,8 @@ create table select_member
     PRIMARY KEY (poll_item_id, member_id)
 );
 
-CREATE INDEX `index_poll` ON `poll` (`closed_at`);
+CREATE INDEX `poll_index_closed_at` ON `poll` (`closed_at`);
+CREATE INDEX `poll_index_code` ON `poll` (`code`);
 
 CREATE TABLE appointment
 (

--- a/backend/src/main/resources/schema-local.sql
+++ b/backend/src/main/resources/schema-local.sql
@@ -60,18 +60,18 @@ CREATE TABLE team_invitation
 
 CREATE TABLE poll
 (
-    id            BIGINT       NOT NULL AUTO_INCREMENT,
-    allowed_count INT          NOT NULL,
-    anonymous     BOOLEAN      NOT NULL,
-    code          VARCHAR(255) NOT NULL,
-    host_id       BIGINT       NOT NULL,
-    status        VARCHAR(255) NOT NULL,
-    team_code     VARCHAR(255) NOT NULL,
-    title         VARCHAR(255) NOT NULL,
-    closed_at     DATETIME     NOT NULL,
-    count         INTEGER      NOT NULL DEFAULT 0,
-    created_at    DATETIME     NOT NULL,
-    updated_at    DATETIME     NOT NULL,
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    allowed_count  INT          NOT NULL,
+    anonymous      BOOLEAN      NOT NULL,
+    code           VARCHAR(255) NOT NULL,
+    host_id        BIGINT       NOT NULL,
+    status         VARCHAR(255) NOT NULL,
+    team_code      VARCHAR(255) NOT NULL,
+    title          VARCHAR(255) NOT NULL,
+    closed_at      DATETIME     NOT NULL,
+    selected_count INTEGER      NOT NULL DEFAULT 0,
+    created_at     DATETIME     NOT NULL,
+    updated_at     DATETIME     NOT NULL,
     PRIMARY KEY (id)
 );
 

--- a/backend/src/main/resources/schema-local.sql
+++ b/backend/src/main/resources/schema-local.sql
@@ -69,6 +69,7 @@ CREATE TABLE poll
     team_code     VARCHAR(255) NOT NULL,
     title         VARCHAR(255) NOT NULL,
     closed_at     DATETIME     NOT NULL,
+    count         INTEGER      NOT NULL DEFAULT 0,
     created_at    DATETIME     NOT NULL,
     updated_at    DATETIME     NOT NULL,
     PRIMARY KEY (id)

--- a/backend/src/test/java/com/morak/back/performance/Fixture.java
+++ b/backend/src/test/java/com/morak/back/performance/Fixture.java
@@ -5,7 +5,6 @@ import static com.morak.back.appointment.AppointmentCreateRequestFixture.모락_
 import static com.morak.back.appointment.AppointmentCreateRequestFixture.모락_회식_첫째날_5시부터_5시반_선택_요청_데이터;
 
 import com.morak.back.appointment.ui.dto.AvailableTimeRequest;
-import com.morak.back.auth.domain.Member;
 import com.morak.back.poll.application.dto.PollCreateRequest;
 import com.morak.back.poll.application.dto.PollResultRequest;
 import com.morak.back.team.ui.dto.TeamCreateRequest;

--- a/backend/src/test/java/com/morak/back/performance/PerformanceTest.java
+++ b/backend/src/test/java/com/morak/back/performance/PerformanceTest.java
@@ -63,13 +63,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql(scripts = {"classpath:schema.sql"})
-@ActiveProfiles(value = "performance")
 @EnabledIf(expression = "#{environment['spring.profiles.active'] == 'performance'}", loadContext = true)
 class PerformanceTest {
 

--- a/backend/src/test/java/com/morak/back/poll/application/PollServiceTest.java
+++ b/backend/src/test/java/com/morak/back/poll/application/PollServiceTest.java
@@ -106,7 +106,8 @@ class PollServiceTest {
                 () -> assertThat(pollResponse.getAllowedPollCount()).isEqualTo(pollCreateRequest.getAllowedPollCount()),
                 () -> assertThat(pollResponse.getIsAnonymous()).isEqualTo(pollCreateRequest.getAnonymous()),
                 () -> assertThat(pollResponse.getClosedAt()).isEqualTo(pollCreateRequest.getClosedAt()),
-                () -> assertThat(pollResponse.getCode()).isNotNull()
+                () -> assertThat(pollResponse.getCode()).isNotNull(),
+                () -> assertThat(pollResponse.getCount()).isEqualTo(0)
         );
     }
 
@@ -316,7 +317,7 @@ class PollServiceTest {
     }
 
     @Test
-    void 투표를_진행한다() {
+    void 투표를_진행한다(@Autowired EntityManager em) {
         // given
         String pollCode = 투표를_초기화하고_코드를_받아온다();
 
@@ -325,7 +326,11 @@ class PollServiceTest {
                 new PollResultRequest(2L, "ㅋ"));
         pollService.doPoll(team.getCode(), member.getId(), pollCode, pollResultRequests);
 
+        em.flush();
+        em.clear();
+
         PollResponse pollResponse = pollService.findPoll(team.getCode(), member.getId(), pollCode);
+
         // then
         assertThat(pollResponse.getCount()).isEqualTo(1);
     }
@@ -488,7 +493,7 @@ class PollServiceTest {
     }
 
     @Test
-    void 투표_진행_후_단건_조회_시_count값이_반영된다(@Autowired EntityManager entityManager) {
+    void 투표_진행_후_단건_조회_시_count값이_반영된다(@Autowired EntityManager em) {
         // given
         String pollCode = 투표를_초기화하고_코드를_받아온다();
         pollService.doPoll(team.getCode(), member.getId(), pollCode,
@@ -505,7 +510,8 @@ class PollServiceTest {
         pollService.doPoll(team.getCode(), 엘리.getId(), pollCode,
                 List.of(new PollResultRequest(1L, "그냥그냥그냐앙~")));
 
-        entityManager.flush();
+        em.flush();
+        em.clear();
 
         // when
         PollResponse pollResponse = pollService.findPoll(team.getCode(), member.getId(), pollCode);

--- a/backend/src/test/java/com/morak/back/poll/application/PollServiceTest.java
+++ b/backend/src/test/java/com/morak/back/poll/application/PollServiceTest.java
@@ -317,7 +317,7 @@ class PollServiceTest {
     }
 
     @Test
-    void 투표를_진행한다(@Autowired EntityManager em) {
+    void 투표를_진행한다(@Autowired EntityManager entityManager) {
         // given
         String pollCode = 투표를_초기화하고_코드를_받아온다();
 
@@ -326,8 +326,8 @@ class PollServiceTest {
                 new PollResultRequest(2L, "ㅋ"));
         pollService.doPoll(team.getCode(), member.getId(), pollCode, pollResultRequests);
 
-        em.flush();
-        em.clear();
+        entityManager.flush();
+        entityManager.clear();
 
         PollResponse pollResponse = pollService.findPoll(team.getCode(), member.getId(), pollCode);
 
@@ -493,7 +493,7 @@ class PollServiceTest {
     }
 
     @Test
-    void 투표_진행_후_단건_조회_시_count값이_반영된다(@Autowired EntityManager em) {
+    void 투표_진행_후_단건_조회_시_count값이_반영된다(@Autowired EntityManager entityManager) {
         // given
         String pollCode = 투표를_초기화하고_코드를_받아온다();
         pollService.doPoll(team.getCode(), member.getId(), pollCode,
@@ -510,8 +510,8 @@ class PollServiceTest {
         pollService.doPoll(team.getCode(), 엘리.getId(), pollCode,
                 List.of(new PollResultRequest(1L, "그냥그냥그냐앙~")));
 
-        em.flush();
-        em.clear();
+        entityManager.flush();
+        entityManager.clear();
 
         // when
         PollResponse pollResponse = pollService.findPoll(team.getCode(), member.getId(), pollCode);

--- a/backend/src/test/java/com/morak/back/poll/domain/PollRepositoryTest.java
+++ b/backend/src/test/java/com/morak/back/poll/domain/PollRepositoryTest.java
@@ -49,15 +49,6 @@ class PollRepositoryTest {
         assertThat(foundPoll).isEqualTo(poll);
     }
 
-    @Test
-    void 코드로_투표를_불러온다_fetched() {
-        // when
-        Poll foundPoll = pollRepository.findFetchedByCode(poll.getCode()).orElseThrow();
-
-        // then
-        assertThat(foundPoll).isEqualTo(poll);
-    }
-
     private Team saveTeam() {
         return teamRepository.save(
                 Team.builder()

--- a/backend/src/test/java/com/morak/back/poll/domain/PollTest.java
+++ b/backend/src/test/java/com/morak/back/poll/domain/PollTest.java
@@ -63,7 +63,7 @@ class PollTest {
     @Test
     void 투표_생성시_count는_0이다() {
         // then
-        assertThat(poll.getCount()).isEqualTo(0);
+        assertThat(poll.getSelectedCount()).isEqualTo(0);
     }
 
     @Test
@@ -101,7 +101,7 @@ class PollTest {
                 () -> assertThat(itemA.getSelectMembers()).containsExactly(entry(member.getId(), descriptionA)),
                 () -> assertThat(itemB.getSelectMembers()).hasSize(0),
                 () -> assertThat(itemC.getSelectMembers()).containsExactly(entry(member.getId(), descriptionC)),
-                () -> assertThat(poll.getCount()).isEqualTo(1)
+                () -> assertThat(poll.getSelectedCount()).isEqualTo(1)
         );
     }
 
@@ -120,7 +120,7 @@ class PollTest {
                 () -> assertThat(itemA.getSelectMembers()).isEmpty(),
                 () -> assertThat(itemB.getSelectMembers()).containsExactly(entry(member.getId(), descriptionB)),
                 () -> assertThat(itemC.getSelectMembers()).isEmpty(),
-                () -> assertThat(poll.getCount()).isEqualTo(1)
+                () -> assertThat(poll.getSelectedCount()).isEqualTo(1)
         );
     }
 
@@ -140,7 +140,7 @@ class PollTest {
                         entry(member.getId(), descriptionA), entry(otherMember.getId(), descriptionA)),
                 () -> assertThat(itemB.getSelectMembers()).containsExactly(entry(otherMember.getId(), descriptionB)),
                 () -> assertThat(itemC.getSelectMembers()).containsExactly(entry(member.getId(), descriptionC)),
-                () -> assertThat(poll.getCount()).isEqualTo(2)
+                () -> assertThat(poll.getSelectedCount()).isEqualTo(2)
         );
     }
 

--- a/backend/src/test/java/com/morak/back/poll/domain/PollTest.java
+++ b/backend/src/test/java/com/morak/back/poll/domain/PollTest.java
@@ -85,9 +85,7 @@ class PollTest {
     @Test
     void 투표를_진행한다() {
         // given
-        Map<PollItem, String> selectData = new HashMap<>();
-        selectData.put(itemA, descriptionA);
-        selectData.put(itemC, descriptionC);
+        Map<Long, String> selectData = Map.of(itemA.getId(), descriptionA, itemC.getId(), descriptionC);
 
         // when
         poll.doPoll(member.getId(), selectData);
@@ -103,14 +101,11 @@ class PollTest {
     @Test
     void 재투표를_진행한다() {
         // given
-        Map<PollItem, String> selectData1 = new HashMap<>();
-        selectData1.put(itemA, descriptionA);
-        selectData1.put(itemC, descriptionC);
+        Map<Long, String> selectData1 = Map.of(itemA.getId(), descriptionA, itemC.getId(), descriptionC);
         poll.doPoll(member.getId(), selectData1);
 
         // when
-        Map<PollItem, String> selectData2 = new HashMap<>();
-        selectData2.put(itemB, descriptionB);
+        Map<Long, String> selectData2 = Map.of(itemB.getId(), descriptionB);
         poll.doPoll(member.getId(), selectData2);
 
         // then
@@ -124,15 +119,11 @@ class PollTest {
     @Test
     void 여러명의_멤버가_투표를_진행한다() {
         // given
-        Map<PollItem, String> selectData1 = new HashMap<>();
-        selectData1.put(itemA, descriptionA);
-        selectData1.put(itemC, descriptionC);
+        Map<Long, String> selectData1 = Map.of(itemA.getId(), descriptionA, itemC.getId(), descriptionC);
         poll.doPoll(member.getId(), selectData1);
 
         // when
-        Map<PollItem, String> selectData2 = new HashMap<>();
-        selectData2.put(itemA, descriptionA);
-        selectData2.put(itemB, descriptionB);
+        Map<Long, String> selectData2 = Map.of(itemA.getId(), descriptionA, itemB.getId(), descriptionB);
         poll.doPoll(otherMember.getId(), selectData2);
 
         // then
@@ -148,10 +139,11 @@ class PollTest {
     @Test
     void 투표하는_선택_항목의_개수가_허용_개수보다_많으면_예외를_던진다() {
         // given
-        Map<PollItem, String> selectData = new HashMap<>();
-        selectData.put(itemA, descriptionA);
-        selectData.put(itemB, descriptionB);
-        selectData.put(itemC, descriptionC);
+        Map<Long, String> selectData = Map.of(
+                itemA.getId(), descriptionA,
+                itemB.getId(), descriptionB,
+                itemC.getId(), descriptionC
+        );
 
         // when & then
         assertThatThrownBy(() -> poll.doPoll(member.getId(), selectData))
@@ -204,9 +196,7 @@ class PollTest {
         // given
         poll.close(member.getId());
 
-        Map<PollItem, String> selectData = new HashMap<>();
-        selectData.put(itemA, descriptionA);
-        selectData.put(itemC, descriptionC);
+        Map<Long, String> selectData = Map.of(itemA.getId(), descriptionA, itemC.getId(), descriptionC);
 
         // when & then
         assertThatThrownBy(() -> poll.doPoll(member.getId(), selectData))
@@ -218,14 +208,9 @@ class PollTest {
     @Test
     void 투표에_속하지_않은_선택항목에_투표하려는_경우_예외를_던진다() {
         // given
-        PollItem itemD = PollItem.builder()
-                .id(4L)
-                .subject("서브웨이")
-                .build();
+        Long invalidId = 4L;
 
-        Map<PollItem, String> selectData = new HashMap<>();
-        selectData.put(itemC, descriptionC);
-        selectData.put(itemD, "");
+        Map<Long, String> selectData = Map.of(itemC.getId(), descriptionC, invalidId, "");
 
         // when & then
         assertThatThrownBy(() -> poll.doPoll(member.getId(), selectData))

--- a/backend/src/test/java/com/morak/back/poll/domain/PollTest.java
+++ b/backend/src/test/java/com/morak/back/poll/domain/PollTest.java
@@ -61,6 +61,12 @@ class PollTest {
     }
 
     @Test
+    void 투표_생성시_count는_0이다() {
+        // then
+        assertThat(poll.getCount()).isEqualTo(0);
+    }
+
+    @Test
     void 투표_생성시_마감_시간이_현재보다_이전이면_예외를_던진다() {
         // when & then
         assertThatThrownBy(() -> defaultPollBuilder()
@@ -94,7 +100,8 @@ class PollTest {
         Assertions.assertAll(
                 () -> assertThat(itemA.getSelectMembers()).containsExactly(entry(member.getId(), descriptionA)),
                 () -> assertThat(itemB.getSelectMembers()).hasSize(0),
-                () -> assertThat(itemC.getSelectMembers()).containsExactly(entry(member.getId(), descriptionC))
+                () -> assertThat(itemC.getSelectMembers()).containsExactly(entry(member.getId(), descriptionC)),
+                () -> assertThat(poll.getCount()).isEqualTo(1)
         );
     }
 
@@ -112,7 +119,8 @@ class PollTest {
         Assertions.assertAll(
                 () -> assertThat(itemA.getSelectMembers()).isEmpty(),
                 () -> assertThat(itemB.getSelectMembers()).containsExactly(entry(member.getId(), descriptionB)),
-                () -> assertThat(itemC.getSelectMembers()).isEmpty()
+                () -> assertThat(itemC.getSelectMembers()).isEmpty(),
+                () -> assertThat(poll.getCount()).isEqualTo(1)
         );
     }
 
@@ -128,11 +136,11 @@ class PollTest {
 
         // then
         Assertions.assertAll(
-                () -> assertThat(itemA.getSelectMembers()).containsOnly(entry(member.getId(), descriptionA),
-                        entry(otherMember.getId(), descriptionA)),
-                () -> assertThat(itemB.getSelectMembers()).containsExactly(
-                        entry(otherMember.getId(), descriptionB)),
-                () -> assertThat(itemC.getSelectMembers()).containsExactly(entry(member.getId(), descriptionC))
+                () -> assertThat(itemA.getSelectMembers()).containsOnly(
+                        entry(member.getId(), descriptionA), entry(otherMember.getId(), descriptionA)),
+                () -> assertThat(itemB.getSelectMembers()).containsExactly(entry(otherMember.getId(), descriptionB)),
+                () -> assertThat(itemC.getSelectMembers()).containsExactly(entry(member.getId(), descriptionC)),
+                () -> assertThat(poll.getCount()).isEqualTo(2)
         );
     }
 

--- a/backend/src/test/resources/data.sql
+++ b/backend/src/test/resources/data.sql
@@ -37,4 +37,4 @@ VALUES ('MoraK123', 2, '발표 준비 날짜 정하기', '데모 데이 발표 �
         60, 'OPEN', 'FEsd23C1', '2022-07-31T23:59:00', now(), now());
 
 INSERT INTO slack_webhook (team_id, url, created_at, updated_at)
-VALUES (1L, 'https://slack.webhook.com/', now(), now());
+VALUES (1, 'https://slack.webhook.com/', now(), now());

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -72,7 +72,8 @@ CREATE TABLE poll
     selected_count INTEGER      NOT NULL DEFAULT 0,
     created_at     DATETIME     NOT NULL,
     updated_at     DATETIME     NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (team_code) REFERENCES team (code)
 );
 
 CREATE TABLE poll_item
@@ -80,7 +81,8 @@ CREATE TABLE poll_item
     id      BIGINT NOT NULL AUTO_INCREMENT,
     subject VARCHAR(255),
     poll_id BIGINT NOT NULL,
-    PRIMARY KEY (id)
+    PRIMARY KEY (id),
+    FOREIGN KEY (poll_id) REFERENCES poll (id)
 );
 
 create table select_member
@@ -88,12 +90,13 @@ create table select_member
     poll_item_id BIGINT        NOT NULL,
     description  VARCHAR(1000) NOT NULL,
     member_id    BIGINT        NOT NULL,
-    PRIMARY KEY (poll_item_id, member_id)
+    PRIMARY KEY (poll_item_id, member_id),
+    FOREIGN KEY (poll_item_id) REFERENCES poll_item (id),
+    FOREIGN KEY (member_id) REFERENCES member (id)
 );
 
 CREATE INDEX `poll_index_closed_at` ON `poll` (`closed_at`);
 CREATE INDEX `poll_index_code` ON `poll` (`code`);
-CREATE INDEX `poll_index_team_code` ON `poll` (`team_code`);
 
 CREATE TABLE appointment
 (

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -60,18 +60,18 @@ CREATE TABLE team_invitation
 
 CREATE TABLE poll
 (
-    id            BIGINT       NOT NULL AUTO_INCREMENT,
-    allowed_count INT          NOT NULL,
-    anonymous     BOOLEAN      NOT NULL,
-    code          VARCHAR(255) NOT NULL,
-    host_id       BIGINT       NOT NULL,
-    status        VARCHAR(255) NOT NULL,
-    team_code     VARCHAR(255) NOT NULL,
-    title         VARCHAR(255) NOT NULL,
-    closed_at     DATETIME     NOT NULL,
-    count         INTEGER      NOT NULL DEFAULT 0,
-    created_at    DATETIME     NOT NULL,
-    updated_at    DATETIME     NOT NULL,
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    allowed_count  INT          NOT NULL,
+    anonymous      BOOLEAN      NOT NULL,
+    code           VARCHAR(255) NOT NULL,
+    host_id        BIGINT       NOT NULL,
+    status         VARCHAR(255) NOT NULL,
+    team_code      VARCHAR(255) NOT NULL,
+    title          VARCHAR(255) NOT NULL,
+    closed_at      DATETIME     NOT NULL,
+    selected_count INTEGER      NOT NULL DEFAULT 0,
+    created_at     DATETIME     NOT NULL,
+    updated_at     DATETIME     NOT NULL,
     PRIMARY KEY (id)
 );
 

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -91,7 +91,9 @@ create table select_member
     PRIMARY KEY (poll_item_id, member_id)
 );
 
-CREATE INDEX `index_poll` ON `poll` (`closed_at`);
+CREATE INDEX `poll_index_closed_at` ON `poll` (`closed_at`);
+CREATE INDEX `poll_index_code` ON `poll` (`code`);
+
 
 CREATE TABLE appointment
 (

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -93,7 +93,7 @@ create table select_member
 
 CREATE INDEX `poll_index_closed_at` ON `poll` (`closed_at`);
 CREATE INDEX `poll_index_code` ON `poll` (`code`);
-
+CREATE INDEX `poll_index_team_code` ON `poll` (`team_code`);
 
 CREATE TABLE appointment
 (

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -69,6 +69,7 @@ CREATE TABLE poll
     team_code     VARCHAR(255) NOT NULL,
     title         VARCHAR(255) NOT NULL,
     closed_at     DATETIME     NOT NULL,
+    count         INTEGER      NOT NULL DEFAULT 0,
     created_at    DATETIME     NOT NULL,
     updated_at    DATETIME     NOT NULL,
     PRIMARY KEY (id)


### PR DESCRIPTION
## 상세 내용

Close #546 

### 투표 쪽 쿼리 성능을 개선했습니다. (조회 성능 개선에 초점을 맞추었습니다.)

1. batch size를 1000으로 설정했습니다. 
2. poll 테이블에 count 컬럼을 추가하는 반정규화를 진행했습니다. 
3. 조회 조건으로 사용되는 컬럼(code)에 인덱스를 생성해주었습니다. 
4. 데이터 정합성을 위해 외래키 컬럼에 대해서는 직접 인덱스를 생성하는 방식이 아닌 FK 제약 조건을 걸어주었습니다. 

- OneToMany 상황에서 join fetch를 이용해 Many 쪽 데이터를 불러오는 경우, One 쪽 데이터가 Many 만큼 중복 조회되는 문제가 있습니다. 이를 distinct나 limit 등으로 해결하기 보다는 batch size 설정으로 1 + 1 + 1 쿼리로 불러오는데 만족했습니다. 
- Poll 삭제 시 CascadeType.REMOVE가 적용되어 PollItem과 SelectMember 까지 모두 삭제되는 데 단건으로 쿼리가 나갑니다. 여기에 Batch Delete를 적용하는 방법을 찾아보다 실패했습니다.

### before/after
![image](https://user-images.githubusercontent.com/45311765/199635175-722b5502-c42f-4743-b496-f552b0151f81.png)

### [개발일지](https://www.notion.so/ririhan/BE-df9cae45dcdd4879a026a79e0a9ddbf3)
