### PR TITLE
fix: 약속잡기 추천시 무한루프 버그 수정

### DIFF
--- a/backend/src/main/java/com/morak/back/appointment/domain/Appointment.java
+++ b/backend/src/main/java/com/morak/back/appointment/domain/Appointment.java
@@ -126,8 +126,9 @@ public class Appointment extends BaseRootEntity<Appointment> {
         LocalDate endDate = datePeriod.getEndDate();
         LocalDate date = datePeriod.getStartDate();
 
-        for (; !date.isAfter(endDate); date = date.plusDays(1L)) {
+        while (!date.isAfter(endDate)) {
             times.addAll(getAppointmentPerDate(date));
+            date = date.plusDays(1L);
         }
         return times;
     }
@@ -135,13 +136,14 @@ public class Appointment extends BaseRootEntity<Appointment> {
     private List<AppointmentTime> getAppointmentPerDate(LocalDate date) {
         List<AppointmentTime> times = new ArrayList<>();
 
-        LocalTime startTime = timePeriod.getStartTime();
-        LocalTime endTime = timePeriod.getEndTime();
         int durationMinutes = this.durationMinutes.getDurationMinutes();
-        long duration = (long) durationMinutes - MINUTES_UNIT;
+        LocalDateTime startDateTime = LocalDateTime.of(date, timePeriod.getStartTime());
+        LocalDateTime endDateTime = LocalDateTime.of(date, timePeriod.getEndTime());
 
-        for (; !startTime.plusMinutes(duration).isAfter(endTime); startTime = startTime.plusMinutes(MINUTES_UNIT)) {
-            times.add(new AppointmentTime(LocalDateTime.of(date, startTime), durationMinutes));
+        int duration = durationMinutes - MINUTES_UNIT;
+        while (!startDateTime.plusMinutes(duration).isAfter(endDateTime)) {
+            times.add(new AppointmentTime(startDateTime, durationMinutes));
+            startDateTime = startDateTime.plusMinutes(MINUTES_UNIT);
         }
         return times;
     }

--- a/backend/src/test/java/com/morak/back/appointment/domain/AppointmentTest.java
+++ b/backend/src/test/java/com/morak/back/appointment/domain/AppointmentTest.java
@@ -120,6 +120,31 @@ class AppointmentTest {
         assertThat(appointmentTimes).hasSize(5 * 8);
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "0, 30, 48",
+            "1, 0, 47",
+            "2, 0, 45",
+            "24, 0, 1"
+    })
+    void 하루종일_약속잡기의_약속시간_후보를_얻어온다(int hours, int minutes, int expected) {
+        // given
+        Appointment appointment = DEFAULT_BUILDER
+                .startDate(now.toLocalDate().plusDays(1))
+                .endDate(now.toLocalDate().plusDays(1))
+                .durationHours(hours)
+                .durationMinutes(minutes)
+                .startTime(LocalTime.of(0, 0))
+                .endTime(LocalTime.of(0, 0))
+                .build();
+
+        // when
+        List<AppointmentTime> appointmentTimes = appointment.getAppointmentTimes();
+
+        // then
+        assertThat(appointmentTimes).hasSize(expected);
+    }
+
     @Test
     void durationMinutes객체의_시간의_시를_얻어온다() {
         // given


### PR DESCRIPTION
## 상세 내용

약속잡기 추천시 무한루프 버그를 해결했습니다.
LocalTime으로만 비교해서, 23:30 과 00:00 분을 비교하는 순간 break 조건에 포함되지 않아서 무한루프가 발생했습니다.
LocalDateTime으로 만들어서 해결했습니다.

Close #559 
