### PR TITLE
feat: 모바일(320 * 480) 대응 

### DIFF
--- a/frontend/src/components/Tooltip/Tooltip.styles.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.styles.tsx
@@ -17,6 +17,7 @@ const StyledContentContainer = styled.div<
 >(
   ({ isVisible, backgroundColor, width, theme, placementStyle }) => `
     ${placementStyle};
+    z-index: 1;
     position: absolute;
     display: ${isVisible ? 'block' : 'none'};  
     background: ${backgroundColor ? backgroundColor : theme.colors.PURPLE_50}; 

--- a/frontend/src/layouts/NavigationLayout/NavigationLayout.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/NavigationLayout.styles.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import responsive from '../../utils/responsive';
 
 const StyledContainer = styled.div`
+  position: relative;
   display: flex;
 
   ${responsive.mobile(`

--- a/frontend/src/layouts/NavigationLayout/NavigationLayout.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/NavigationLayout.styles.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+const StyledContainer = styled.div<{
+  isMobile: boolean;
+}>(
+  ({ isMobile }) => `
+  display: ${isMobile ? 'block' : 'flex'};
+`
+);
+
+export { StyledContainer };

--- a/frontend/src/layouts/NavigationLayout/NavigationLayout.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/NavigationLayout.styles.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled';
+import responsive from '../../utils/responsive';
 
-const StyledContainer = styled.div<{
-  isMobile: boolean;
-}>(
-  ({ isMobile }) => `
-  display: ${isMobile ? 'block' : 'flex'};
-`
-);
+const StyledContainer = styled.div`
+  display: flex;
+
+  ${responsive.mobile(`
+    display: block;
+  `)}
+`;
 
 export { StyledContainer };

--- a/frontend/src/layouts/NavigationLayout/NavigationLayout.tsx
+++ b/frontend/src/layouts/NavigationLayout/NavigationLayout.tsx
@@ -11,7 +11,7 @@ function NavigationLayout() {
   const navigationBar = isMobile ? <GlobalFootbar /> : <Sidebar />;
 
   return (
-    <StyledContainer isMobile={isMobile}>
+    <StyledContainer>
       <NavigationBarProvider>
         <GroupMembersProvider>
           {navigationBar}

--- a/frontend/src/layouts/NavigationLayout/NavigationLayout.tsx
+++ b/frontend/src/layouts/NavigationLayout/NavigationLayout.tsx
@@ -1,9 +1,9 @@
 import { Outlet } from 'react-router-dom';
-import FlexContainer from '../../components/FlexContainer/FlexContainer';
 import { GroupMembersProvider } from '../../context/GroupMembersProvider';
 import { NavigationBarProvider } from '../../context/NavigationBarProvider';
 import useDeviceState from '../../hooks/useDeviceState';
 import GlobalFootbar from './components/GlobalFootbar/GlobalFootbar';
+import { StyledContainer } from './NavigationLayout.styles';
 import Sidebar from './components/Sidebar/Sidebar';
 
 function NavigationLayout() {
@@ -11,14 +11,14 @@ function NavigationLayout() {
   const navigationBar = isMobile ? <GlobalFootbar /> : <Sidebar />;
 
   return (
-    <FlexContainer>
+    <StyledContainer isMobile={isMobile}>
       <NavigationBarProvider>
         <GroupMembersProvider>
           {navigationBar}
           <Outlet />
         </GroupMembersProvider>
       </NavigationBarProvider>
-    </FlexContainer>
+    </StyledContainer>
   );
 }
 

--- a/frontend/src/layouts/NavigationLayout/components/GlobalFootbar/GlobalFootbar.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/components/GlobalFootbar/GlobalFootbar.styles.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
 const StyledContainer = styled.div`
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
 `;
 
 export { StyledContainer };

--- a/frontend/src/layouts/NavigationLayout/components/GlobalFootbar/GlobalFootbar.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/components/GlobalFootbar/GlobalFootbar.styles.tsx
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+
+const StyledContainer = styled.div`
+  width: 100vw;
+  height: 100vh;
+`;
+
+export { StyledContainer };

--- a/frontend/src/layouts/NavigationLayout/components/GlobalFootbarFootbar/GlobalFootbarFootbar.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/components/GlobalFootbarFootbar/GlobalFootbarFootbar.styles.tsx
@@ -7,7 +7,7 @@ const StyledContainer = styled.div(
   justify-content: space-evenly;
   position: fixed;
   bottom: 0;
-  z-index: 999; // TODO: 상수화
+  z-index: 998; // TODO: 상수화
   width: 100%;
   height: 10%;
   background:${theme.colors.WHITE_100}; 

--- a/frontend/src/layouts/NavigationLayout/components/GlobalFootbarFootbar/GlobalFootbarFootbar.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/components/GlobalFootbarFootbar/GlobalFootbarFootbar.styles.tsx
@@ -7,7 +7,7 @@ const StyledContainer = styled.div(
   justify-content: space-evenly;
   position: fixed;
   bottom: 0;
-  z-index: 1;
+  z-index: 999; // TODO: 상수화
   width: 100%;
   height: 10%;
   background:${theme.colors.WHITE_100}; 

--- a/frontend/src/layouts/NavigationLayout/components/GlobalFootbarFootbarDrawer/GlobalFootbarFootbarDrawer.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/components/GlobalFootbarFootbarDrawer/GlobalFootbarFootbarDrawer.styles.tsx
@@ -8,7 +8,7 @@ const StyledContainer = styled.div<{ isVisible: boolean }>(
   top: 0;
   width: 100%;
   min-height: 100%;
-  z-index: 1; 
+  z-index: 999; 
   background: ${theme.colors.WHITE_100};
   padding: 4rem;
   gap: 2rem;

--- a/frontend/src/layouts/NavigationLayout/components/GlobalFootbarGlobalbar/GlobalFootbarGlobalbar.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/components/GlobalFootbarGlobalbar/GlobalFootbarGlobalbar.styles.tsx
@@ -10,7 +10,7 @@ const StyledContainer = styled.div(
   align-items: center;
   justify-content: space-between;
   padding-left: 2rem;
-  z-index: 1;
+  z-index: 999; // TODO: 상수화
   background:${theme.colors.WHITE_100};
 `
 );

--- a/frontend/src/layouts/NavigationLayout/components/GlobalFootbarGlobalbar/GlobalFootbarGlobalbar.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/components/GlobalFootbarGlobalbar/GlobalFootbarGlobalbar.styles.tsx
@@ -2,15 +2,15 @@ import styled from '@emotion/styled';
 
 const StyledContainer = styled.div(
   ({ theme }) => `
+  position: sticky;
+  top: 0;
+  width: 100vw;
+  height: 10vh;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  position: fixed;
-  top: 0;
   padding-left: 2rem;
   z-index: 1;
-  width: 100%;
-  height: 10%;
   background:${theme.colors.WHITE_100};
 `
 );

--- a/frontend/src/layouts/NavigationLayout/components/GlobalFootbarGlobalbar/GlobalFootbarGlobalbar.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/components/GlobalFootbarGlobalbar/GlobalFootbarGlobalbar.styles.tsx
@@ -10,7 +10,7 @@ const StyledContainer = styled.div(
   align-items: center;
   justify-content: space-between;
   padding-left: 2rem;
-  z-index: 999; // TODO: 상수화
+  z-index: 998; // TODO: 상수화
   background:${theme.colors.WHITE_100};
 `
 );

--- a/frontend/src/layouts/NavigationLayout/components/GlobalFootbarGlobalbar/GlobalFootbarGlobalbar.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/components/GlobalFootbarGlobalbar/GlobalFootbarGlobalbar.styles.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 const StyledContainer = styled.div(
   ({ theme }) => `
-  position: sticky;
+  position: fixed;
   top: 0;
   width: 100vw;
   height: 10vh;

--- a/frontend/src/layouts/NavigationLayout/components/Sidebar/Sidebar.styles.tsx
+++ b/frontend/src/layouts/NavigationLayout/components/Sidebar/Sidebar.styles.tsx
@@ -7,7 +7,7 @@ const StyledContainer = styled.div(
   top: 0;
   width: 36.4rem;
   height: 100vh;
-  z-index: 1; 
+  z-index: 999; 
   background: ${theme.colors.WHITE_100};
   padding-left: 4rem;
   gap: 2rem;

--- a/frontend/src/pages/AppointmentCreatePage/AppointmentCreatePage.styles.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/AppointmentCreatePage.styles.tsx
@@ -11,8 +11,7 @@ const StyledContainer = styled.div`
   ${responsive.mobile(`
     align-items: flex-start;
     width: 100%;
-    padding: 0 8rem;
-    margin-top: 8rem;
+    padding: 20rem 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/AppointmentCreatePage/AppointmentCreatePage.styles.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/AppointmentCreatePage.styles.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import responsive from '../../utils/responsive';
 
 const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
@@ -6,6 +7,12 @@ const StyledContainer = styled.div`
   align-items: center;
   justify-content: center;
   gap: 6rem;
+
+  ${responsive.mobile(`
+    width: 100%;
+    height: 100vh;
+    padding: 0 8rem;
+  `)}
 `;
 
 const StyledLeftContainer = styled.div`

--- a/frontend/src/pages/AppointmentCreatePage/AppointmentCreatePage.styles.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/AppointmentCreatePage.styles.tsx
@@ -9,9 +9,10 @@ const StyledContainer = styled.div`
   gap: 6rem;
 
   ${responsive.mobile(`
+    align-items: flex-start;
     width: 100%;
-    height: 100vh;
     padding: 0 8rem;
+    margin-top: 8rem;
   `)}
 `;
 
@@ -20,6 +21,10 @@ const StyledLeftContainer = styled.div`
   width: 45.2rem;
   flex-direction: column;
   gap: 1.8rem;
+
+  ${responsive.mobile(`
+    align-items: center; 
+  `)}
 `;
 
 const StyledRightContainer = styled.div`
@@ -28,4 +33,14 @@ const StyledRightContainer = styled.div`
   gap: 4rem;
 `;
 
-export { StyledContainer, StyledLeftContainer, StyledRightContainer };
+const StyledContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  ${responsive.mobile(`
+    width: 100%;
+  `)}
+`;
+
+export { StyledContainer, StyledLeftContainer, StyledRightContainer, StyledContentContainer };

--- a/frontend/src/pages/AppointmentCreatePage/AppointmentCreatePage.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/AppointmentCreatePage.tsx
@@ -6,7 +6,8 @@ import FlexContainer from '../../components/FlexContainer/FlexContainer';
 import {
   StyledContainer,
   StyledLeftContainer,
-  StyledRightContainer
+  StyledRightContainer,
+  StyledContentContainer
 } from './AppointmentCreatePage.styles';
 
 function AppointmentCreatePage() {
@@ -15,9 +16,9 @@ function AppointmentCreatePage() {
 
   return (
     <StyledContainer>
-      <FlexContainer flexDirection="column" gap="2rem">
+      <StyledContentContainer>
         <AppointmentCreateHeader />
-        <FlexContainer gap="4rem">
+        <FlexContainer gap="4rem" flexWrap="wrap" justifyContent="center">
           <StyledLeftContainer>
             <Calendar
               startDate={startDate}
@@ -30,7 +31,7 @@ function AppointmentCreatePage() {
             <AppointmentCreateForm startDate={startDate} endDate={endDate} />
           </StyledRightContainer>
         </FlexContainer>
-      </FlexContainer>
+      </StyledContentContainer>
     </StyledContainer>
   );
 }

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.styles.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.styles.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import responsive from '../../../../utils/responsive';
 
 const StyledForm = styled.form`
-  width: 66rem;
+  width: 64rem;
   display: flex;
   flex-direction: column;
   gap: 3.2rem;

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.styles.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.styles.tsx
@@ -1,14 +1,15 @@
 import styled from '@emotion/styled';
+import responsive from '../../../../utils/responsive';
 
-const StyledForm = styled.form<{
-  isMobile: boolean;
-}>(
-  ({ isMobile }) => `
-  width: ${isMobile ? '52rem' : '66rem'};
+const StyledForm = styled.form`
+  width: 66rem;
   display: flex;
   flex-direction: column;
   gap: 3.2rem;
-`
-);
+
+  ${responsive.mobile(`
+    width: 52rem;
+  `)}
+`;
 
 export { StyledForm };

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.styles.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.styles.tsx
@@ -1,9 +1,14 @@
 import styled from '@emotion/styled';
 
-const StyledForm = styled.form`
+const StyledForm = styled.form<{
+  isMobile: boolean;
+}>(
+  ({ isMobile }) => `
+  width: ${isMobile ? '52rem' : '66rem'};
   display: flex;
   flex-direction: column;
   gap: 3.2rem;
-`;
+`
+);
 
 export { StyledForm };

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.tsx
@@ -15,6 +15,7 @@ import { Time, CreateAppointmentRequest, Appointment } from '../../../../types/a
 import { createAppointment } from '../../../../api/appointment';
 import { Group } from '../../../../types/group';
 import { StyledForm } from './AppointmentCreateForm.styles';
+import useDeviceState from '../../../../hooks/useDeviceState';
 
 const getFormattedTime = (time: Time) => {
   const { period, hour, minute } = time;
@@ -36,6 +37,7 @@ type Props = {
 
 function AppointmentCreateForm({ startDate, endDate }: Props) {
   const navigate = useNavigate();
+  const isMobile = useDeviceState();
   const [title, handleTitle] = useInput('');
   const { groupCode } = useParams() as { groupCode: Group['code'] };
   const [description, handleDescription] = useInput('');
@@ -124,8 +126,8 @@ function AppointmentCreateForm({ startDate, endDate }: Props) {
   return (
     // TODO: StyledForm처럼 컴포넌트의 역할을 담은 네이밍을 해줄 것인지? S
     // StyledContainer처럼 최상단은 무조건 StyledContainer로 해줄 것인지 컨벤션 정해서 통일
-    <StyledForm onSubmit={handleCreateAppointment}>
-      <Box width="66rem" padding="4.8rem" height="60rem">
+    <StyledForm onSubmit={handleCreateAppointment} isMobile={isMobile}>
+      <Box width="100%" padding="4.8rem" height="60rem">
         <FlexContainer flexDirection="column" gap="2rem">
           <AppointmentCreateFormTitleInput title={title} onChange={handleTitle} />
           <AppointmentCreateFormDescriptionInput

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateForm/AppointmentCreateForm.tsx
@@ -15,7 +15,6 @@ import { Time, CreateAppointmentRequest, Appointment } from '../../../../types/a
 import { createAppointment } from '../../../../api/appointment';
 import { Group } from '../../../../types/group';
 import { StyledForm } from './AppointmentCreateForm.styles';
-import useDeviceState from '../../../../hooks/useDeviceState';
 
 const getFormattedTime = (time: Time) => {
   const { period, hour, minute } = time;
@@ -37,7 +36,6 @@ type Props = {
 
 function AppointmentCreateForm({ startDate, endDate }: Props) {
   const navigate = useNavigate();
-  const isMobile = useDeviceState();
   const [title, handleTitle] = useInput('');
   const { groupCode } = useParams() as { groupCode: Group['code'] };
   const [description, handleDescription] = useInput('');
@@ -126,7 +124,7 @@ function AppointmentCreateForm({ startDate, endDate }: Props) {
   return (
     // TODO: StyledForm처럼 컴포넌트의 역할을 담은 네이밍을 해줄 것인지? S
     // StyledContainer처럼 최상단은 무조건 StyledContainer로 해줄 것인지 컨벤션 정해서 통일
-    <StyledForm onSubmit={handleCreateAppointment} isMobile={isMobile}>
+    <StyledForm onSubmit={handleCreateAppointment}>
       <Box width="100%" padding="4.8rem" height="60rem">
         <FlexContainer flexDirection="column" gap="2rem">
           <AppointmentCreateFormTitleInput title={title} onChange={handleTitle} />

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.styles.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.styles.tsx
@@ -29,7 +29,6 @@ const StyledContent = styled.p`
 const StyledHeader = styled.div`
   display: flex;
   gap: 2rem;
-  z-index: 1;
 `;
 
 export { StyledTitle, StyledHelpIconContainer, StyledHelpIcon, StyledContent, StyledHeader };

--- a/frontend/src/pages/AppointmentMainPage/AppointmentMainPage.styles.tsx
+++ b/frontend/src/pages/AppointmentMainPage/AppointmentMainPage.styles.tsx
@@ -10,8 +10,7 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    padding: 0 8rem;
-    margin-top: 8rem;
+    padding: 20rem 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/AppointmentMainPage/AppointmentMainPage.styles.tsx
+++ b/frontend/src/pages/AppointmentMainPage/AppointmentMainPage.styles.tsx
@@ -10,7 +10,8 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    padding: 20rem 8rem;
+    padding: 0 8rem;
+    margin-top: 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/AppointmentMainPage/AppointmentMainPage.styles.tsx
+++ b/frontend/src/pages/AppointmentMainPage/AppointmentMainPage.styles.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import responsive from '../../utils/responsive';
 
 const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
@@ -6,6 +7,11 @@ const StyledContainer = styled.div`
   flex-direction: column;
   gap: 4rem;
   padding: 6.4rem 20rem;
+
+  ${responsive.mobile(`
+    width: 100%;
+    padding: 20rem 8rem;
+  `)}
 `;
 
 export { StyledContainer };

--- a/frontend/src/pages/AppointmentMainPage/components/AppointmentMainButtons/AppointmentMainButtons.tsx
+++ b/frontend/src/pages/AppointmentMainPage/components/AppointmentMainButtons/AppointmentMainButtons.tsx
@@ -22,7 +22,7 @@ function AppointmentMainButtons({ appointmentCode, isClosed }: Props) {
       {!isClosed && (
         <Button
           variant="filled"
-          width="8.4rem"
+          width="24%"
           padding="0.8rem 0"
           fontSize="1.2rem"
           borderRadius="5px"
@@ -34,7 +34,7 @@ function AppointmentMainButtons({ appointmentCode, isClosed }: Props) {
       )}
       <Button
         variant="outlined"
-        width="8.4rem"
+        width="24%"
         padding="0.8rem 0"
         fontSize="1.2rem"
         borderRadius="5px"

--- a/frontend/src/pages/AppointmentMainPage/components/AppointmentMainStatus/AppointmentMainStatus.tsx
+++ b/frontend/src/pages/AppointmentMainPage/components/AppointmentMainStatus/AppointmentMainStatus.tsx
@@ -12,7 +12,7 @@ function AppointmentMainStatus({ isClosed }: Props) {
   return (
     <TextField
       variant="filled"
-      width="7.2rem"
+      width="20%"
       padding="0.8rem 0"
       borderRadius="5px"
       colorScheme={!isClosed ? theme.colors.PURPLE_100 : theme.colors.GRAY_400}

--- a/frontend/src/pages/AppointmentProgressPage/AppointmentProgressPage.styles.tsx
+++ b/frontend/src/pages/AppointmentProgressPage/AppointmentProgressPage.styles.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import responsive from '../../utils/responsive';
 
 const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
@@ -7,6 +8,12 @@ const StyledContainer = styled.div`
   align-items: center;
   justify-content: center;
   gap: 8rem;
+
+  ${responsive.mobile(`
+    width: 100%;
+    height: 100vh;
+    padding: 0 8rem;
+  `)}
 `;
 
 const StyledLeftContainer = styled.div`

--- a/frontend/src/pages/AppointmentProgressPage/AppointmentProgressPage.styles.tsx
+++ b/frontend/src/pages/AppointmentProgressPage/AppointmentProgressPage.styles.tsx
@@ -11,8 +11,8 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    height: 100vh;
     padding: 0 8rem;
+    margin-top: 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/AppointmentProgressPage/AppointmentProgressPage.styles.tsx
+++ b/frontend/src/pages/AppointmentProgressPage/AppointmentProgressPage.styles.tsx
@@ -11,8 +11,7 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    padding: 0 8rem;
-    margin-top: 8rem;
+    padding: 20rem 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/AppointmentProgressPage/AppointmentProgressPage.tsx
+++ b/frontend/src/pages/AppointmentProgressPage/AppointmentProgressPage.tsx
@@ -138,7 +138,7 @@ function AppointmentProgressPage() {
       {appointment ? (
         <FlexContainer flexDirection="column" gap="2rem">
           <AppointmentProgressHeader appointment={appointment} />
-          <FlexContainer gap="4rem">
+          <FlexContainer gap="4rem" flexWrap="wrap" justifyContent="center">
             <StyledLeftContainer>
               <Calendar
                 version="select"

--- a/frontend/src/pages/AppointmentResultPage/AppointmentResultPage.styles.tsx
+++ b/frontend/src/pages/AppointmentResultPage/AppointmentResultPage.styles.tsx
@@ -9,9 +9,19 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    height: 100vh;
     padding: 0 8rem;
+    margin-top: 8rem;
   `)}
 `;
 
-export { StyledContainer };
+const StyledContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+
+  ${responsive.mobile(`
+    width: 100%;
+  `)}
+`;
+
+export { StyledContainer, StyledContentContainer };

--- a/frontend/src/pages/AppointmentResultPage/AppointmentResultPage.styles.tsx
+++ b/frontend/src/pages/AppointmentResultPage/AppointmentResultPage.styles.tsx
@@ -9,8 +9,7 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    padding: 0 8rem;
-    margin-top: 8rem;
+    padding: 20rem 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/AppointmentResultPage/AppointmentResultPage.styles.tsx
+++ b/frontend/src/pages/AppointmentResultPage/AppointmentResultPage.styles.tsx
@@ -1,10 +1,17 @@
 import styled from '@emotion/styled';
+import responsive from '../../utils/responsive';
 
 const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
   display: flex;
   align-items: center;
   justify-content: center;
+
+  ${responsive.mobile(`
+    width: 100%;
+    height: 100vh;
+    padding: 0 8rem;
+  `)}
 `;
 
 export { StyledContainer };

--- a/frontend/src/pages/AppointmentResultPage/AppointmentResultPage.tsx
+++ b/frontend/src/pages/AppointmentResultPage/AppointmentResultPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { StyledContainer } from './AppointmentResultPage.styles';
+import { StyledContainer, StyledContentContainer } from './AppointmentResultPage.styles';
 import { getAppointment, getAppointmentRecommendation } from '../../api/appointment';
 import {
   Appointment,
@@ -68,7 +68,7 @@ function AppointmentResultPage() {
   return (
     <StyledContainer>
       {appointment ? (
-        <FlexContainer flexDirection="column" gap="4rem">
+        <StyledContentContainer>
           <AppointmentResultHeader
             groupCode={groupCode}
             appointmentCode={appointmentCode}
@@ -76,7 +76,7 @@ function AppointmentResultPage() {
             isClosed={appointment.isClosed}
             closedAt={appointment.closedAt}
           />
-          <FlexContainer gap="4rem">
+          <FlexContainer gap="4rem" flexWrap="wrap">
             <AppointmentResultRanking
               appointmentRecommendation={appointmentRecommendation}
               clickedRecommendation={clickedRecommendation}
@@ -96,7 +96,7 @@ function AppointmentResultPage() {
             isHost={appointment.isHost}
             setIsClosed={setIsClosed}
           />
-        </FlexContainer>
+        </StyledContentContainer>
       ) : (
         <Spinner width="15%" placement="center" />
       )}

--- a/frontend/src/pages/AppointmentResultPage/components/AppointmentResultRanking/AppointmentResultRanking.styles.tsx
+++ b/frontend/src/pages/AppointmentResultPage/components/AppointmentResultRanking/AppointmentResultRanking.styles.tsx
@@ -10,7 +10,7 @@ const StyledResultBox = styled.div(
   height: 59.6rem;
   overflow-y: auto;
   border-radius: 15px;
-  padding: 2rem 0;
+  padding: 2rem;
   
   background-color: ${theme.colors.WHITE_100};
   box-shadow: 0px 4px 4px ${theme.colors.TRANSPARENT_BLACK_100_25};
@@ -31,11 +31,10 @@ const StyledRank = styled.div<{
   // NOTE: 아래처럼 변수 사용하는 것은 밑으로 빼줘도 괜찮을듯?
   ({ theme, isClicked }) => `
   text-align: center;
-  width: 66.8rem;
+  width: 100%;
   border-radius: 0.8rem;
   padding: 2rem 4.4rem;
   cursor: pointer;
-  
   border: 0.1rem solid ${theme.colors.TRANSPARENT_BLACK_100_25};
   box-shadow: 0px 4px 4px ${theme.colors.TRANSPARENT_BLACK_100_25};
   background-color: ${isClicked ? theme.colors.PURPLE_100 : theme.colors.WHITE_100};

--- a/frontend/src/pages/MainPage/MainPage.styles.tsx
+++ b/frontend/src/pages/MainPage/MainPage.styles.tsx
@@ -8,7 +8,10 @@ const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
   padding: 6.4rem 20rem;
 
-  ${responsive.mobile(`width: 100%`)}
+  ${responsive.mobile(`
+    width: 100%;
+    padding: 20rem 8rem;
+  `)}
 `;
 
 export { StyledContainer };

--- a/frontend/src/pages/MainPage/MainPage.styles.tsx
+++ b/frontend/src/pages/MainPage/MainPage.styles.tsx
@@ -10,8 +10,7 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    padding: 0 8rem;
-    margin-top: 8rem;
+    padding: 20rem 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/MainPage/MainPage.styles.tsx
+++ b/frontend/src/pages/MainPage/MainPage.styles.tsx
@@ -10,7 +10,8 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    padding: 20rem 8rem;
+    padding: 0 8rem;
+    margin-top: 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/PollCreatePage/PollCreatePage.styles.tsx
+++ b/frontend/src/pages/PollCreatePage/PollCreatePage.styles.tsx
@@ -8,9 +8,10 @@ const StyledContainer = styled.div`
   justify-content: center;
 
   ${responsive.mobile(`
+    align-items: flex-start;
     width: 100%;
-    height: 100vh;
     padding: 0 8rem;
+    margin-top: 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/PollCreatePage/PollCreatePage.styles.tsx
+++ b/frontend/src/pages/PollCreatePage/PollCreatePage.styles.tsx
@@ -1,13 +1,17 @@
 import styled from '@emotion/styled';
+import responsive from '../../utils/responsive';
 
 const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
   display: flex;
   align-items: center;
   justify-content: center;
-  /* TODO: 위니랑 이야기해보기 */
-  /* margin: 8rem 0;
-  height: 100%; */
+
+  ${responsive.mobile(`
+    width: 100%;
+    height: 100vh;
+    padding: 0 8rem;
+  `)}
 `;
 
 export { StyledContainer };

--- a/frontend/src/pages/PollCreatePage/PollCreatePage.styles.tsx
+++ b/frontend/src/pages/PollCreatePage/PollCreatePage.styles.tsx
@@ -10,8 +10,7 @@ const StyledContainer = styled.div`
   ${responsive.mobile(`
     align-items: flex-start;
     width: 100%;
-    padding: 0 8rem;
-    margin-top: 8rem;
+    padding: 20rem 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/PollMainPage/PollMainPage.styles.tsx
+++ b/frontend/src/pages/PollMainPage/PollMainPage.styles.tsx
@@ -10,8 +10,7 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    padding: 0 8rem;
-    margin-top: 8rem;
+    padding: 20rem 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/PollMainPage/PollMainPage.styles.tsx
+++ b/frontend/src/pages/PollMainPage/PollMainPage.styles.tsx
@@ -10,7 +10,8 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    padding: 20rem 8rem;
+    padding: 0 8rem;
+    margin-top: 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/PollMainPage/PollMainPage.styles.tsx
+++ b/frontend/src/pages/PollMainPage/PollMainPage.styles.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import responsive from '../../utils/responsive';
 
 const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
@@ -6,6 +7,11 @@ const StyledContainer = styled.div`
   flex-direction: column;
   gap: 4rem;
   padding: 6.4rem 20rem;
+
+  ${responsive.mobile(`
+    width: 100%;
+    padding: 20rem 8rem;
+  `)}
 `;
 
 export { StyledContainer };

--- a/frontend/src/pages/PollMainPage/components/PollMainButtons/PollMainButtons.tsx
+++ b/frontend/src/pages/PollMainPage/components/PollMainButtons/PollMainButtons.tsx
@@ -23,7 +23,7 @@ function PollMainButtons({ pollCode, status }: Props) {
         <Button
           type="button"
           variant="filled"
-          width="8.4rem"
+          width="24%"
           padding="0.8rem 0"
           fontSize="1.2rem"
           borderRadius="5px"
@@ -36,7 +36,7 @@ function PollMainButtons({ pollCode, status }: Props) {
       <Button
         type="button"
         variant="outlined"
-        width="8.4rem"
+        width="24%"
         padding="0.8rem 0"
         fontSize="1.2rem"
         borderRadius="5px"

--- a/frontend/src/pages/PollMainPage/components/PollMainStatus/PollMainStatus.tsx
+++ b/frontend/src/pages/PollMainPage/components/PollMainStatus/PollMainStatus.tsx
@@ -13,7 +13,7 @@ function PollMainStatus({ status }: Props) {
   return (
     <TextField
       variant="filled"
-      width="7.2rem"
+      width="20%"
       padding="0.8rem 0"
       borderRadius="5px"
       colorScheme={status === 'OPEN' ? theme.colors.PURPLE_100 : theme.colors.GRAY_400}

--- a/frontend/src/pages/PollProgressPage/PollProgressPage.styles.tsx
+++ b/frontend/src/pages/PollProgressPage/PollProgressPage.styles.tsx
@@ -8,9 +8,10 @@ const StyledContainer = styled.div`
   justify-content: center;
 
   ${responsive.mobile(`
+    align-items: flex-start;
     width: 100%;
-    height: 100vh;
     padding: 0 8rem;
+    margin-top: 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/PollProgressPage/PollProgressPage.styles.tsx
+++ b/frontend/src/pages/PollProgressPage/PollProgressPage.styles.tsx
@@ -1,10 +1,17 @@
 import styled from '@emotion/styled';
+import responsive from '../../utils/responsive';
 
 const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
   display: flex;
   align-items: center;
   justify-content: center;
+
+  ${responsive.mobile(`
+    width: 100%;
+    height: 100vh;
+    padding: 0 8rem;
+  `)}
 `;
 
 export { StyledContainer };

--- a/frontend/src/pages/PollProgressPage/PollProgressPage.styles.tsx
+++ b/frontend/src/pages/PollProgressPage/PollProgressPage.styles.tsx
@@ -10,8 +10,7 @@ const StyledContainer = styled.div`
   ${responsive.mobile(`
     align-items: flex-start;
     width: 100%;
-    padding: 0 8rem;
-    margin-top: 8rem;
+    padding: 20rem 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/PollProgressPage/components/PollProgressButtons/PollProgressButtons.tsx
+++ b/frontend/src/pages/PollProgressPage/components/PollProgressButtons/PollProgressButtons.tsx
@@ -41,7 +41,7 @@ function PollProgressButtons({ pollCode, isHost, groupCode }: Props) {
       {isHost && (
         <Button
           variant="filled"
-          width="46rem"
+          width="50%"
           padding="2rem 0"
           colorScheme={theme.colors.GRAY_400}
           fontSize="2rem"
@@ -52,7 +52,7 @@ function PollProgressButtons({ pollCode, isHost, groupCode }: Props) {
       )}
       <Button
         variant="filled"
-        width="46rem"
+        width="50%"
         padding="2rem 0"
         colorScheme={theme.colors.PURPLE_100}
         fontSize="2rem"

--- a/frontend/src/pages/PollProgressPage/components/PollProgressItems/PollProgressItems.tsx
+++ b/frontend/src/pages/PollProgressPage/components/PollProgressItems/PollProgressItems.tsx
@@ -45,7 +45,6 @@ function PollProgressItems({
             <TextField
               colorScheme={theme.colors.PURPLE_100}
               padding="1.2rem 0"
-              width="74.4rem"
               variant="outlined"
               borderRadius="10px"
             >
@@ -74,7 +73,6 @@ function PollProgressItems({
             <StyledDescription isVisible={isSelectedPollItem}>
               <TextField
                 colorScheme={theme.colors.PURPLE_100}
-                width="74.4rem"
                 variant="outlined"
                 borderRadius="10px"
                 padding="1.2rem 0"

--- a/frontend/src/pages/PollProgressPage/components/PollProgressItems/PollProgressItems.tsx
+++ b/frontend/src/pages/PollProgressPage/components/PollProgressItems/PollProgressItems.tsx
@@ -75,7 +75,7 @@ function PollProgressItems({
                 colorScheme={theme.colors.PURPLE_100}
                 variant="outlined"
                 borderRadius="10px"
-                padding="1.2rem 0"
+                padding="1.2rem"
               >
                 <Input
                   color={theme.colors.BLACK_100}

--- a/frontend/src/pages/PollResultPage/PollResultPage.styles.tsx
+++ b/frontend/src/pages/PollResultPage/PollResultPage.styles.tsx
@@ -8,9 +8,10 @@ const StyledContainer = styled.div`
   justify-content: center;
 
   ${responsive.mobile(`
+    align-items: flex-start;
     width: 100%;
-    height: 100vh;
     padding: 0 8rem;
+    margin-top: 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/PollResultPage/PollResultPage.styles.tsx
+++ b/frontend/src/pages/PollResultPage/PollResultPage.styles.tsx
@@ -1,10 +1,17 @@
 import styled from '@emotion/styled';
+import responsive from '../../utils/responsive';
 
 const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
   display: flex;
   align-items: center;
   justify-content: center;
+
+  ${responsive.mobile(`
+    width: 100%;
+    height: 100vh;
+    padding: 0 8rem;
+  `)}
 `;
 
 export { StyledContainer };

--- a/frontend/src/pages/PollResultPage/PollResultPage.styles.tsx
+++ b/frontend/src/pages/PollResultPage/PollResultPage.styles.tsx
@@ -10,8 +10,7 @@ const StyledContainer = styled.div`
   ${responsive.mobile(`
     align-items: flex-start;
     width: 100%;
-    padding: 0 8rem;
-    margin-top: 8rem;
+    padding: 20rem 8rem;
   `)}
 `;
 

--- a/frontend/src/pages/PollResultPage/components/PollResultButtons/PollResultButtons.tsx
+++ b/frontend/src/pages/PollResultPage/components/PollResultButtons/PollResultButtons.tsx
@@ -69,9 +69,8 @@ function PollResultButtons({ pollCode, status, setStatus, isHost, groupCode, pol
         {status === 'OPEN' && (
           <FlexContainer gap="2rem" justifyContent="space-between">
             <Button
-              type="button"
               variant="filled"
-              width="22.8rem"
+              width="calc(100% / 3)"
               padding="2rem 0"
               fontSize="2rem"
               colorScheme={theme.colors.GRAY_400}
@@ -80,9 +79,8 @@ function PollResultButtons({ pollCode, status, setStatus, isHost, groupCode, pol
               투표 마감하기
             </Button>
             <Button
-              type="button"
               variant="filled"
-              width="22.8rem"
+              width="calc(100% / 3)"
               padding="2rem 0"
               fontSize="2rem"
               colorScheme={theme.colors.GRAY_400}
@@ -91,9 +89,8 @@ function PollResultButtons({ pollCode, status, setStatus, isHost, groupCode, pol
               투표 삭제하기
             </Button>
             <Button
-              type="button"
               variant="filled"
-              width="22.8rem"
+              width="calc(100% / 3)"
               padding="2rem 0"
               fontSize="2rem"
               colorScheme={theme.colors.PURPLE_100}

--- a/frontend/src/pages/PollResultPage/components/PollResultDetail/PolLResultDetail.styles.tsx
+++ b/frontend/src/pages/PollResultPage/components/PollResultDetail/PolLResultDetail.styles.tsx
@@ -1,15 +1,7 @@
 import styled from '@emotion/styled';
 
-const StyledContainer = styled.div`
-  display: flex;
-  gap: 1.2rem;
-  position: relative;
-`;
-
 const StyledCloseTime = styled.p`
   font-size: 1.2rem;
-  position: absolute;
-  right: 0;
 `;
 
 const StyledDetail = styled.span(
@@ -19,4 +11,4 @@ const StyledDetail = styled.span(
 `
 );
 
-export { StyledContainer, StyledCloseTime, StyledDetail };
+export { StyledCloseTime, StyledDetail };

--- a/frontend/src/pages/PollResultPage/components/PollResultDetail/PollResultDetail.tsx
+++ b/frontend/src/pages/PollResultPage/components/PollResultDetail/PollResultDetail.tsx
@@ -1,9 +1,10 @@
 import { useTheme } from '@emotion/react';
 
-import { StyledContainer, StyledCloseTime, StyledDetail } from './PolLResultDetail.styles';
+import { StyledCloseTime, StyledDetail } from './PolLResultDetail.styles';
 import TextField from '../../../../components/TextField/TextField';
 
 import { Poll } from '../../../../types/poll';
+import FlexContainer from '../../../../components/FlexContainer/FlexContainer';
 
 type Props = Pick<Poll, 'isAnonymous' | 'allowedPollCount' | 'closedAt'>;
 
@@ -26,30 +27,32 @@ function PollResultDetail({ isAnonymous, allowedPollCount, closedAt }: Props) {
   const theme = useTheme();
 
   return (
-    <StyledContainer>
+    <FlexContainer justifyContent="space-between" flexWrap="wrap" gap="1.2rem">
+      <FlexContainer gap="1.2rem">
+        <TextField
+          borderRadius="20px"
+          padding="1.2rem 2rem"
+          variant="outlined"
+          colorScheme={theme.colors.PURPLE_100}
+        >
+          <StyledDetail>{isAnonymous ? '익명' : '기명'}</StyledDetail>
+        </TextField>
+        <TextField
+          borderRadius="20px"
+          padding="1.2rem"
+          variant="outlined"
+          colorScheme={theme.colors.PURPLE_100}
+        >
+          <StyledDetail>
+            {allowedPollCount === 1 ? '하나만 투표가능' : '여러개 투표가능'}
+          </StyledDetail>
+        </TextField>
+      </FlexContainer>
       <StyledCloseTime>
         {getFormattedClosedTime(closedAt)}
         까지
       </StyledCloseTime>
-      <TextField
-        borderRadius="20px"
-        padding="1.2rem 2rem"
-        variant="outlined"
-        colorScheme={theme.colors.PURPLE_100}
-      >
-        <StyledDetail>{isAnonymous ? '익명' : '기명'}</StyledDetail>
-      </TextField>
-      <TextField
-        borderRadius="20px"
-        padding="1.2rem"
-        variant="outlined"
-        colorScheme={theme.colors.PURPLE_100}
-      >
-        <StyledDetail>
-          {allowedPollCount === 1 ? '하나만 투표가능' : '여러개 투표가능'}
-        </StyledDetail>
-      </TextField>
-    </StyledContainer>
+    </FlexContainer>
   );
 }
 

--- a/frontend/src/pages/PollResultPage/components/PollResultDetail/PollResultDetail.tsx
+++ b/frontend/src/pages/PollResultPage/components/PollResultDetail/PollResultDetail.tsx
@@ -30,7 +30,7 @@ function PollResultDetail({ isAnonymous, allowedPollCount, closedAt }: Props) {
     <FlexContainer justifyContent="space-between" flexWrap="wrap" gap="1.2rem">
       <FlexContainer gap="1.2rem">
         <TextField
-          borderRadius="20px"
+          borderRadius="2rem"
           padding="1.2rem 2rem"
           variant="outlined"
           colorScheme={theme.colors.PURPLE_100}
@@ -38,7 +38,7 @@ function PollResultDetail({ isAnonymous, allowedPollCount, closedAt }: Props) {
           <StyledDetail>{isAnonymous ? '익명' : '기명'}</StyledDetail>
         </TextField>
         <TextField
-          borderRadius="20px"
+          borderRadius="2rem"
           padding="1.2rem"
           variant="outlined"
           colorScheme={theme.colors.PURPLE_100}

--- a/frontend/src/pages/RoleMainPage/RoleMainPage.styles.tsx
+++ b/frontend/src/pages/RoleMainPage/RoleMainPage.styles.tsx
@@ -10,8 +10,7 @@ const StyledContainer = styled.div`
 
   ${responsive.mobile(`
     width: 100%;
-    padding: 0 8rem;
-    margin-top: 8rem;
+    padding: 20rem 8rem;
   `)}
 `;
 export { StyledContainer };

--- a/frontend/src/pages/RoleMainPage/RoleMainPage.styles.tsx
+++ b/frontend/src/pages/RoleMainPage/RoleMainPage.styles.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import responsive from '../../utils/responsive';
 
 const StyledContainer = styled.div`
   width: calc(100% - 36.4rem);
@@ -6,5 +7,11 @@ const StyledContainer = styled.div`
   flex-direction: column;
   gap: 4rem;
   padding: 6.4rem 20rem;
+
+  ${responsive.mobile(`
+    width: 100%;
+    padding: 0 8rem;
+    margin-top: 8rem;
+  `)}
 `;
 export { StyledContainer };


### PR DESCRIPTION
## 상세 내용
- 모바일 사이즈에 대응해주었습니다. 
  - 메인 페이지 
  - 투표 페이지 
  - 약속 잡기 페이지 
  - 역할 정하기 페이지 
- 이번 커밋은, **모바일 화면에서 깨지지 않게 대응** 에 목적을 두었습니다. UI적으로 모바일에 완벽히 예쁘지는 않을 수 있어요 😅
- 기존에 재사용 컴포넌트로 작성한 컴포넌트에 미디어쿼리를 적용해야하는 경우가 생길 때는, 재사용 컴포넌트를 새로운 컴포넌트를 만들어서 대체해주는 것이 좋을까요? 아니면 더 좋은 방식이 있을까요? 
  예를들어, 아래는 역할 정하기 페이지 대응화면인데요 (현재 pr에 올라간 코드는 아래 캡처본과 같습니다.) 
  <img width="343" alt="스크린샷 2022-11-04 오후 9 40 49" src="https://user-images.githubusercontent.com/52344833/199974858-c90568a7-5b45-4044-b893-ddf81d32c03b.png">
  모바일에서는 왼쪽 박스, 오른쪽 박스의 width를 100%로 줘서 아래와 같이 만들어주고싶었습니다. 
  <img width="280" alt="스크린샷 2022-11-04 오후 9 42 24" src="https://user-images.githubusercontent.com/52344833/199975135-908abf46-dbed-4c36-868f-847cf9f5461e.png">
  그런데 omg... 
  재사용 컴포넌트인 Box에 width가 적용이 되어있더라구요? 
  
  ```jsx
  <Box width="70%" height="50rem" padding="2rem">
   // 역할 정하기
  </Box>
  <Box width="30%" height="50rem" padding="2rem">
   // 이전 결과
  </Box>
  ```
  사실 이 경우는 새롭게 컴포넌트를 만들어서 미디어쿼리를 적용해주는 것이 맞을지, 고민되네요. 앨버의 생각이 궁금합니다! 

- 대응을 해주면서, 모바일 대응을 위해서는 width를 고정으로 주지 않는 것이 좋다는 말이 와닿네요. %로 했을 때는 화면의 크기에 비례하여 크기가 조정되기 때문에 훨씬 대응에 수월함을 깨달았습니다 👋 

- 모든 페이지 상위 요소에 다음 스타일을 적용했습니다. 
  ```jsx
    ${responsive.mobile(`
      width: 100%;
      padding: 20rem 8rem;
    `)}
  ```
  한번에 줄 수 있는 방식은 없을까? 했지만, 페이지별로 적용되는 스타일이 다른 부분들도 있었기 때문에 데스크탑에서도 그랬던 것 처럼, 따로 따로 주었습니다. 

- ✅ 테스트 완료 

- 아직 미흡한 부분이 많지만, 리뷰 후 점진적으로 개선해보겠슴다 👋


Close #386 
