### PR TITLE
refactor: 툴팁 width에 고정적으로 적용되는 rem 삭제

### DIFF
--- a/frontend/src/components/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.stories.tsx
@@ -24,7 +24,7 @@ const CenteredContainer = styled.div`
 
 const DefaultTemplate: Story = (args) => (
   <CenteredContainer>
-    <Tooltip placement="top" content="툴팁입니다." width="8" {...args}>
+    <Tooltip placement="top" content="툴팁입니다." width="8rem" {...args}>
       <SampleBox />
     </Tooltip>
   </CenteredContainer>

--- a/frontend/src/components/Tooltip/Tooltip.styles.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.styles.tsx
@@ -20,7 +20,7 @@ const StyledContentContainer = styled.div<
     position: absolute;
     display: ${isVisible ? 'block' : 'none'};  
     background: ${backgroundColor ? backgroundColor : theme.colors.PURPLE_50}; 
-    width: ${width}rem;
+    width: ${width};
     border-radius: 1.2rem;
     padding: 2rem;
 `

--- a/frontend/src/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,4 @@
 import { PropsWithChildren, useState } from 'react';
-import { useTheme } from '@emotion/react';
 import closeButtonImg from '../../assets/close-button.svg';
 import {
   StyledContainer,
@@ -9,70 +8,32 @@ import {
   StyledContent
 } from './Tooltip.styles';
 
-type placementStyleProps = Pick<Props, 'placement' | 'backgroundColor'>;
+type placementStyleProps = Pick<Props, 'placement'>;
 
-const getPlacementStyle = ({ placement, backgroundColor }: placementStyleProps) => {
-  const theme = useTheme();
-
+const getPlacementStyle = ({ placement }: placementStyleProps) => {
   // TODO: 중앙정렬 (현재는 위치만 적용)
   switch (placement) {
     case 'top':
       return `
         bottom: 100%;
         margin-bottom: 0.8rem;
-
-        &::after {
-          top: 100%; 
-          left: 50%;
-          margin-left: -5px;
-          border-color: ${
-            backgroundColor || theme.colors.PURPLE_50
-          } transparent transparent transparent;
-        }
       `;
     case 'bottom':
       return `
         top: 100%;
         margin-top: 0.8rem;
-
-        &::after {
-          bottom: 100%; 
-          left: 50%;
-          margin-left: -5px;
-          border-color: transparent transparent ${
-            backgroundColor || theme.colors.PURPLE_50
-          } transparent;
-        }
       `;
     case 'left':
       return `
         top: 0;
         right: 105%;
         margin-right: 0.8rem;
-
-        &::after {
-          top: 50%;
-          left: 100%;
-          margin-top: -5px;
-          border-color: transparent transparent transparent ${
-            backgroundColor || theme.colors.PURPLE_50
-          };
-        }
       `;
     case 'right':
       return `
-        top: -5px;
+        top: 0;
         left: 105%;
         margin-left: 0.8rem;
-
-        &::after {
-          top: 50%;
-          right: 100%; 
-          margin-top: -5px;
-          border-color: transparent ${
-            backgroundColor || theme.colors.PURPLE_50
-          } transparent transparent;
-        }
       `;
     default:
       return '';
@@ -99,7 +60,7 @@ function Tooltip({
 }: Props) {
   const [isVisible, setIsVisible] = useState(false);
 
-  const placementStyle = getPlacementStyle({ placement, backgroundColor });
+  const placementStyle = getPlacementStyle({ placement });
 
   const handleToggleContent = () => {
     setIsVisible(!isVisible);

--- a/frontend/src/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.tsx
@@ -9,17 +9,17 @@ import {
   StyledContent
 } from './Tooltip.styles';
 
-type placementStyleProps = Pick<Props, 'placement' | 'width' | 'backgroundColor'>;
+type placementStyleProps = Pick<Props, 'placement' | 'backgroundColor'>;
 
-const getPlacementStyle = ({ placement, width, backgroundColor }: placementStyleProps) => {
+const getPlacementStyle = ({ placement, backgroundColor }: placementStyleProps) => {
   const theme = useTheme();
 
+  // TODO: 중앙정렬 (현재는 위치만 적용)
   switch (placement) {
     case 'top':
       return `
         bottom: 100%;
-        left: 50%;
-        margin: 0 0 0.8rem ${-width / 2}rem;
+        margin-bottom: 0.8rem;
 
         &::after {
           top: 100%; 
@@ -33,8 +33,7 @@ const getPlacementStyle = ({ placement, width, backgroundColor }: placementStyle
     case 'bottom':
       return `
         top: 100%;
-        left: 50%;
-        margin: 0.8rem 0 0 ${-width / 2}rem;
+        margin-top: 0.8rem;
 
         &::after {
           bottom: 100%; 
@@ -47,10 +46,9 @@ const getPlacementStyle = ({ placement, width, backgroundColor }: placementStyle
       `;
     case 'left':
       return `
-        top: -5px;
+        top: 0;
         right: 105%;
         margin-right: 0.8rem;
-        // TODO: 중앙 정렬 (툴팁 -height / 2rem)
 
         &::after {
           top: 50%;
@@ -66,7 +64,6 @@ const getPlacementStyle = ({ placement, width, backgroundColor }: placementStyle
         top: -5px;
         left: 105%;
         margin-left: 0.8rem;
-        // TODO: 중앙 정렬 ( -height / 2rem)
 
         &::after {
           top: 50%;
@@ -102,7 +99,7 @@ function Tooltip({
 }: Props) {
   const [isVisible, setIsVisible] = useState(false);
 
-  const placementStyle = getPlacementStyle({ placement, width, backgroundColor });
+  const placementStyle = getPlacementStyle({ placement, backgroundColor });
 
   const handleToggleContent = () => {
     setIsVisible(!isVisible);

--- a/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
+++ b/frontend/src/pages/AppointmentCreatePage/components/AppointmentCreateFormTimeLimitInput/AppointmentCreateFormTimeLimitInput.tsx
@@ -34,7 +34,7 @@ function AppointmentCreateFormTimeLimitInput({
         <StyledTitle>가능 시간 제한 설정</StyledTitle>
         <Tooltip
           content="오전 12:00 ~ 오전 12:00(다음날)은 하루종일을 의미합니다."
-          width="28"
+          width="28rem"
           placement="right"
           fontSize="1.6rem"
           backgroundColor={theme.colors.GRAY_200}

--- a/frontend/src/pages/AppointmentResultPage/components/AppointmentResultButtons/AppointmentResultButtons.tsx
+++ b/frontend/src/pages/AppointmentResultPage/components/AppointmentResultButtons/AppointmentResultButtons.tsx
@@ -160,7 +160,7 @@ function AppointmentResultButtons({
               </Button>
               <Tooltip
                 content="공동 1등이 나왔네요! 공동 1등에 대한 재투표를 생성할 수 있습니다."
-                width="28"
+                width="28rem"
                 placement="right"
                 backgroundColor={theme.colors.GRAY_200}
                 fontSize="1.6rem"

--- a/frontend/src/pages/AppointmentResultPage/components/AppointmentResultHeader/AppointmentResultHeader.tsx
+++ b/frontend/src/pages/AppointmentResultPage/components/AppointmentResultHeader/AppointmentResultHeader.tsx
@@ -74,7 +74,7 @@ function AppointmentResultHeader({ groupCode, appointmentCode, title, isClosed, 
           </StyledContent>
           <Tooltip
             content="공동 1등이 나오면, 마감 이후 재투표를 빠르게 진행할 수 있어요!"
-            width="28"
+            width="28rem"
             placement="bottom"
             fontSize="1.6rem"
             backgroundColor={theme.colors.GRAY_200}

--- a/frontend/src/pages/PollResultPage/components/PollResultContainer/PollResultContainer.tsx
+++ b/frontend/src/pages/PollResultPage/components/PollResultContainer/PollResultContainer.tsx
@@ -101,7 +101,7 @@ function PollResultContainer() {
               <MarginContainer margin="1.2rem 0 0">
                 <Tooltip
                   content="사람 아이콘을 클릭해보세요. 항목별로 투표 한 사람들과 이유를 볼 수 있어요 👀"
-                  width="32"
+                  width="32rem"
                   placement="bottom"
                   backgroundColor={theme.colors.PURPLE_50}
                   fontSize="1.6rem"


### PR DESCRIPTION
## 상세 내용
- ✅ 테스트 통과 완료!

- 원래 tooltip 컴포넌트에서 아래와같이 고정적으로 width에 rem을 적용하고 있었습니다. 
하지만 tooltip이 재사용 컴포넌트인만큼, width를 고정적인 단위로만 받는다는 것이 재사용성을 떨어트리기 때문에, 고정적으로 받고있던 rem을 삭제하고 사용하는 곳에서 단위까지 붙혀서 사용할 수 있도록 만들어주었습니다. 
  ```jsx
  width: ${width}rem;
  ```
- 위의 수정에 따라, 기존 Tooltip 컴포넌트를 사용하고 있는 곳에서 width에 단위를 붙혀주었습니다. 
- 수정하다보니, 제가 width에 rem을 넣어 줬던 이유가 있더라구요? 🙃
아래 코드 부분인데요, 아래 코드는 툴팁의 위치를 조정해주는 스타일을 return하는 `getPlacementStyle` 함수입니다. 그 중 일부인 top을 가져와봤어요. 
  ```jsx
  const getPlacementStyle = ({ placement }: placementStyleProps) => {
    switch (placement) {
      case 'top':
        return `
          bottom: 100%;
          left: 50%;
          margin: 0 0 0.8rem ${-width / 2}rem; // 🚨 요기!
        `;
      // ...
  ```
  만약, width가 20rem과 같이 들어온다면 위에서 -20rem/2가 되기 때문에 NaN이 나옵니다... 그래서 고정적으로 width에 rem을 넣어준 것으로 보이네요!  (wow) 
  하지만 이 방식은 항상 같은 단위(rem)가 고정되어있는 것이기 때문에 위에서 말한 것 처럼, 재사용 컴포넌트에 좋지 않은 방식이라고 판단했습니다. 
  현재 margin은 중앙정렬을 위해 넣은 코드이지만, 사실 완벽히 제대로 동작하고있지 않습니다. 중앙 정렬이 제대로 동작하지 않고 있기 때문에 이 코드는 불필요한 코드라고 판단되어 이 부분은 제거를 하고, top, bottom, left, right에 따른 배치만 잘 되도록 코드를 남겨놓았습니다. 아래는 스토리 캡처본입니다. (차례대로 top, right에 대한 배치)
  <img width="254" alt="스크린샷 2022-11-05 오전 2 47 11" src="https://user-images.githubusercontent.com/52344833/200042034-41cc3466-a585-408b-a515-5f0f1f6f84cf.png">
  <img width="270" alt="스크린샷 2022-11-05 오전 2 47 25" src="https://user-images.githubusercontent.com/52344833/200042069-836d222f-1b51-4ac2-be4e-f978dc498ec0.png">

  🤔 김위니씨, 중앙정렬은 왜 제대로 안되고있나요? 
  <img width="658" alt="스크린샷 2022-11-05 오전 2 55 29" src="https://user-images.githubusercontent.com/52344833/200043569-822803c3-dd25-4673-b115-32f94e7d04b5.png">
  얘는 약속잡기 결과페이지에있는 툴팁입니다. 
  FlexContainer 내부에 있다보니 tooltip의 영역이 자신이 실제로 차지하고있는 영역보다 더 넓게잡혀서, 여기서 중앙정렬을 해버리면... 매우 엉뚱한곳에 배치가 됩니다^ㅇ^: tooltip을 사용하는 곳에서 딱! 자기 영역만큼만 차지하도록 하면 중앙 정렬이 잘 되지만, 지금같은 경우는 엉뚱하게 배치됩니다. 그래서 일단은 깔끔하게, 언제든지 top, bottom, left, right 배치가 잘 이루어지도록 남겨놨습니다. 
  tooltip을 사용할 때 사용자가 이런것 (툴팁을 사용할 때는 중앙정렬을 위해 딱 자기자신의 영역만큼 width를 차지하게 해주세요)까지 신경쓰도록 하면 사용성이 떨어질 것 같은데, 어떻게 생각하시나요~? 
  중앙정렬에 대해서는... 계속해서 구글링해보고 고민해보겠습니다! 

- 이전에 말풍선 꼬리를 삭제해주면서, 관련 style 속성을 덜 지웠더라구요. 이번에 모두 삭제해주었습니다 :) 



Close #567
