### PR TITLE
feat: 그룹 생성 및 참가 페이지의 접근성 개선 

### DIFF
--- a/frontend/src/pages/GroupInitPage/components/GroupCreateFormNameInput/GroupCreateFormNameInput.tsx
+++ b/frontend/src/pages/GroupInitPage/components/GroupCreateFormNameInput/GroupCreateFormNameInput.tsx
@@ -24,7 +24,7 @@ function GroupCreateFormNameInput({ groupName, onChange }: Props) {
       borderRadius="10px 0 0 10px"
       padding="2.8rem 8rem"
     >
-      <StyledCreateIcon src={createPlusImg} alt="create-group-icon" />
+      <StyledCreateIcon src={createPlusImg} alt="그룹 생성 아이콘" aria-hidden="true" />
       <Input
         placeholder="그룹이름을 입력해주세요!"
         value={groupName}

--- a/frontend/src/pages/GroupInitPage/components/GroupInitContainer/GroupInitContainer.styles.tsx
+++ b/frontend/src/pages/GroupInitPage/components/GroupInitContainer/GroupInitContainer.styles.tsx
@@ -31,12 +31,12 @@ const StyledLogo = styled.img`
   margin-bottom: 4rem;
 `;
 
-const StyledBigText = styled.div`
+const StyledBigText = styled.h1`
   font-size: 4.4rem;
   margin-bottom: 2rem;
 `;
 
-const StyledSmallText = styled.div`
+const StyledSmallText = styled.p`
   font-size: 2.4rem;
   padding: 0 4rem;
   text-align: center;

--- a/frontend/src/pages/GroupInitPage/components/GroupInitContainer/GroupInitContainer.styles.tsx
+++ b/frontend/src/pages/GroupInitPage/components/GroupInitContainer/GroupInitContainer.styles.tsx
@@ -31,12 +31,12 @@ const StyledLogo = styled.img`
   margin-bottom: 4rem;
 `;
 
-const StyledBigText = styled.h1`
+const StyledTitle = styled.h1`
   font-size: 4.4rem;
   margin-bottom: 2rem;
 `;
 
-const StyledSmallText = styled.p`
+const StyledDescription = styled.p`
   font-size: 2.4rem;
   padding: 0 4rem;
   text-align: center;
@@ -48,6 +48,6 @@ export {
   StyledTopContainer,
   StyledBottomContainer,
   StyledLogo,
-  StyledBigText,
-  StyledSmallText
+  StyledTitle,
+  StyledDescription
 };

--- a/frontend/src/pages/GroupInitPage/components/GroupInitContainer/GroupInitContainer.tsx
+++ b/frontend/src/pages/GroupInitPage/components/GroupInitContainer/GroupInitContainer.tsx
@@ -16,7 +16,7 @@ function GroupInitContainer() {
   return (
     <StyledContainer>
       <StyledTopContainer>
-        <StyledLogo src={serviceLogoImg} alt="logo" />
+        <StyledLogo src={serviceLogoImg} alt="모락 로고" aria-hidden="true" />
         <StyledBigText>새로운 그룹에 참여해볼까요?</StyledBigText>
         <StyledSmallText>
           아직 그룹이 없네요. <br />

--- a/frontend/src/pages/GroupInitPage/components/GroupInitContainer/GroupInitContainer.tsx
+++ b/frontend/src/pages/GroupInitPage/components/GroupInitContainer/GroupInitContainer.tsx
@@ -19,9 +19,7 @@ function GroupInitContainer() {
         <StyledLogo src={serviceLogoImg} alt="모락 로고" aria-hidden="true" />
         <StyledBigText>새로운 그룹에 참여해볼까요?</StyledBigText>
         <StyledSmallText>
-          아직 그룹이 없네요. <br />
-          새로운 그룹을 생성하거나, <br />
-          초대받은 그룹에 참가해서 모락을 시작해보세요!
+          아직 그룹이 없네요. 새로운 그룹을 생성하거나, 초대받은 그룹에 참가해서 모락을 시작해보세요!
         </StyledSmallText>
       </StyledTopContainer>
       <StyledBottomContainer>

--- a/frontend/src/pages/GroupInitPage/components/GroupInitContainer/GroupInitContainer.tsx
+++ b/frontend/src/pages/GroupInitPage/components/GroupInitContainer/GroupInitContainer.tsx
@@ -8,8 +8,8 @@ import {
   StyledTopContainer,
   StyledBottomContainer,
   StyledLogo,
-  StyledBigText,
-  StyledSmallText
+  StyledTitle,
+  StyledDescription
 } from './GroupInitContainer.styles';
 
 function GroupInitContainer() {
@@ -17,10 +17,10 @@ function GroupInitContainer() {
     <StyledContainer>
       <StyledTopContainer>
         <StyledLogo src={serviceLogoImg} alt="모락 로고" aria-hidden="true" />
-        <StyledBigText>새로운 그룹에 참여해볼까요?</StyledBigText>
-        <StyledSmallText>
+        <StyledTitle>새로운 그룹에 참여해볼까요?</StyledTitle>
+        <StyledDescription>
           아직 그룹이 없네요. 새로운 그룹을 생성하거나, 초대받은 그룹에 참가해서 모락을 시작해보세요!
-        </StyledSmallText>
+        </StyledDescription>
       </StyledTopContainer>
       <StyledBottomContainer>
         <GroupCreateForm />

--- a/frontend/src/pages/GroupInitPage/components/GroupParticipateInvitationCodeInput/GroupParticipateInvitationCodeInput.tsx
+++ b/frontend/src/pages/GroupInitPage/components/GroupParticipateInvitationCodeInput/GroupParticipateInvitationCodeInput.tsx
@@ -22,7 +22,7 @@ function GroupParticipateInvitationCodeInput({ invitationCode, handleInvitationC
       borderRadius="10px 0 0 10px"
       padding="2.8rem 8rem"
     >
-      <StyledParticipateIcon src={participateImg} alt="participate-group-icon" />
+      <StyledParticipateIcon src={participateImg} alt="그룹 참가 아이콘" aria-hidden="true" />
       <Input
         placeholder="코드를 입력해주세요!"
         value={invitationCode}


### PR DESCRIPTION
## 상세 내용
- ✅ 테스트 통과 완료!
- 그룹 생성 및 참가 페이지 (`/init`) 의 접근성을 개선했습니다. 다른 기능들의 접근성도 개선하고싶네요! 
- 아이폰 voiceover를 기준으로 다음과 같이 읽어주도록 개선했습니다. 
  ```
  - 새로운 그룹에 참여해볼까요? (머리말 레벨1)
  - 아직 그룹이 없네요. 새로운 그룹을 생성하거나, 초대받은 그룹에 참가해서 모락을 시작해보세요! 
  - 그룹이름을 입력해주세요! (텍스트필드, 편집 하려면 이중탭하세요.)
  - 생성하기 버튼  
  - 코드를 입력해주세요! (텍스트필드, 편집 하려면 이중탭하세요.)
  - 참가하기 버튼
  ```
- 자세한 구현 사항은 [📔 개발 일지 📔](https://ririhan.notion.site/1d515e6304174433a4e4f8d5b549922c)를 참고해주세요.

Close #436
