### PR TITLE
refactor: 약속 생성 시 현재 날짜로부터 1년뒤까지의 날짜까지만 허용하도록 변경

### DIFF
--- a/backend/src/main/java/com/morak/back/appointment/domain/dateperiod/Date.java
+++ b/backend/src/main/java/com/morak/back/appointment/domain/dateperiod/Date.java
@@ -12,10 +12,13 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Date {
 
+    private static final int LIMIT_YEAR = 1;
+
     private LocalDate date;
 
     public Date(LocalDate date, LocalDate today) {
         validateFutureOrPresent(date, today);
+        validateDateAllowedRange(date, today);
         this.date = date;
     }
 
@@ -24,6 +27,15 @@ public class Date {
             throw new AppointmentDomainLogicException(
                     CustomErrorCode.APPOINTMENT_PAST_DATE_CREATE_ERROR,
                     String.format("약속잡기 날짜(%s)는 현재(%s)보다 과거일 수 없습니다.", date, today)
+            );
+        }
+    }
+
+    private void validateDateAllowedRange(LocalDate date, LocalDate today) {
+        if (date.isAfter(today.plusYears(LIMIT_YEAR))) {
+            throw new AppointmentDomainLogicException(
+                    CustomErrorCode.APPOINTMENT_DATE_AFTER_YEAR_ERROR,
+                    String.format("약속잡기 날짜(%s)는 현재(%s)로부터 %d년 뒤까지만 가능합니다.", date, today, LIMIT_YEAR)
             );
         }
     }

--- a/backend/src/main/java/com/morak/back/core/exception/CustomErrorCode.java
+++ b/backend/src/main/java/com/morak/back/core/exception/CustomErrorCode.java
@@ -54,7 +54,7 @@ public enum CustomErrorCode {
     APPOINTMENT_TIME_REVERSE_CHRONOLOGY_ERROR("3110", "약속잡기 마지막 시각은 시작 시각보다 미래여야 합니다."),
     APPOINTMENT_NOT_DIVIDED_BY_MINUTES_UNIT_ERROR("3111", "약속잡기 시작시각, 마지막 시각은 30분 단위여야 합니다."),
     AVAILABLETIME_OUT_OF_RANGE_ERROR("3113", "약속잡기 선택 시간이 약속잡기 시간을 벗어났습니다."),
-    APPOINTMENT_DATE_AFTER_YEAR_ERROR("3114", "약속잡기 날짜는 현재보다 1년 이전의 날짜여야합니다."),
+    APPOINTMENT_DATE_AFTER_YEAR_ERROR("3114", "약속잡기 날짜는 현재로부터 1년 이후일 수 없습니다."),
     APPOINTMENT_CLOSED_AT_OUT_OF_RANGE_ERROR("3117", "약속잡기 마감 시간은 현재 시간과 마지막 날짜/시간 사이여야 합니다."),
 
     APPOINTMENT_HOST_MISMATCHED_ERROR("3200", "멤버가 약속잡기의 호스트가 아닙니다."),

--- a/backend/src/main/java/com/morak/back/core/exception/CustomErrorCode.java
+++ b/backend/src/main/java/com/morak/back/core/exception/CustomErrorCode.java
@@ -54,6 +54,7 @@ public enum CustomErrorCode {
     APPOINTMENT_TIME_REVERSE_CHRONOLOGY_ERROR("3110", "약속잡기 마지막 시각은 시작 시각보다 미래여야 합니다."),
     APPOINTMENT_NOT_DIVIDED_BY_MINUTES_UNIT_ERROR("3111", "약속잡기 시작시각, 마지막 시각은 30분 단위여야 합니다."),
     AVAILABLETIME_OUT_OF_RANGE_ERROR("3113", "약속잡기 선택 시간이 약속잡기 시간을 벗어났습니다."),
+    APPOINTMENT_DATE_AFTER_YEAR_ERROR("3114", "약속잡기 날짜는 현재보다 1년 이전의 날짜여야합니다."),
     APPOINTMENT_CLOSED_AT_OUT_OF_RANGE_ERROR("3117", "약속잡기 마감 시간은 현재 시간과 마지막 날짜/시간 사이여야 합니다."),
 
     APPOINTMENT_HOST_MISMATCHED_ERROR("3200", "멤버가 약속잡기의 호스트가 아닙니다."),

--- a/backend/src/test/java/com/morak/back/appointment/domain/dateperiod/DateTest.java
+++ b/backend/src/test/java/com/morak/back/appointment/domain/dateperiod/DateTest.java
@@ -6,7 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.morak.back.appointment.exception.AppointmentDomainLogicException;
+import com.morak.back.core.exception.CustomErrorCode;
 import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -81,5 +83,29 @@ class DateTest {
 
         // then
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void 현재날짜로부터_1년_이후의_날짜라면_예외를_던진다() {
+        // given
+        LocalDate today = LocalDate.now();
+        LocalDate invalidDate = today.plusYears(1).plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Date(invalidDate, today))
+                .isInstanceOf(AppointmentDomainLogicException.class)
+                .extracting("code")
+                .isEqualTo(CustomErrorCode.APPOINTMENT_DATE_AFTER_YEAR_ERROR);
+    }
+
+    @Test
+    void 현재날짜로부터_1년뒤의_날짜까지는_생성_가능하다() {
+        // given
+        LocalDate today = LocalDate.now();
+        LocalDate invalidDate = today.plusYears(1);
+
+        // when & then
+        assertThatNoException()
+                .isThrownBy(() -> new Date(invalidDate, today));
     }
 }


### PR DESCRIPTION
## 상세 내용

간단하게 변경해보았습니다.

약속 생성 시, 시작 날짜와 끝 날짜 모두 현재날짜보다 1년 이후라면 예외를 던지게 만들었습니다.

기존에 날짜에 제한이 없었기 때문에 발생했던 문제들을 해결할 수 있습니다!

객체 지향적으로 설계했기때문에, 변경지점이 Date 객체밖에 없네요. 좋습니다.

로직은 괜찮은 것 같은데 예외코드 이름이나, 메서드명, 변수명을 더 좋게 만들 수 있을까요?


Close #580 
