### PR TITLE
refactor: PollService에서 SystemTime을 사용하도록 변경

### DIFF
--- a/backend/src/main/java/com/morak/back/poll/application/dto/PollCreateRequest.java
+++ b/backend/src/main/java/com/morak/back/poll/application/dto/PollCreateRequest.java
@@ -40,7 +40,7 @@ public class PollCreateRequest {
     @NotNull(message = "subjects 는 null 일 수 없습니다.")
     private List<String> subjects;
 
-    public Poll toPoll(String teamCode, Long hostId) {
+    public Poll toPoll(String teamCode, Long hostId, LocalDateTime now) {
         List<PollItem> pollItems = subjects.stream()
                 .map(subject -> PollItem.builder().subject(subject).build())
                 .collect(Collectors.toList());
@@ -50,7 +50,7 @@ public class PollCreateRequest {
                 .code(Code.generate(new RandomCodeGenerator()))
                 .title(title)
                 .status(MenuStatus.OPEN)
-                .closedAt(new ClosedAt(closedAt, LocalDateTime.now()))
+                .closedAt(new ClosedAt(closedAt, now))
                 .pollItems(pollItems)
                 .anonymous(anonymous)
                 .allowedCount(allowedPollCount)

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -4,6 +4,8 @@ spring:
   profiles:
     active: test
   jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
     defer-datasource-initialization: true
     show-sql: true
     hibernate:

--- a/backend/src/test/resources/data.sql
+++ b/backend/src/test/resources/data.sql
@@ -29,7 +29,11 @@ VALUES (2, 4, now(), now());
 
 INSERT INTO poll (team_code, host_id, title, allowed_count, anonymous, status, created_at, updated_at, closed_at,
                   code)
-VALUES ('MoraK123', 2, 'test-poll-title', 2, true, 'OPEN', now(), now(), now(), 'testcode');
+VALUES ('MoraK123', 2, 'test-poll-title1', 2, true, 'OPEN', now(), now(), '2022-07-31T23:59:00', 'Testcode');
+
+INSERT INTO poll (team_code, host_id, title, allowed_count, anonymous, status, created_at, updated_at, closed_at,
+                  code)
+VALUES ('MoraK123', 2, 'test-poll-title2', 2, true, 'OPEN', now(), now(), now(), 'testcode');
 
 INSERT INTO appointment (team_code, host_id, title, sub_title, start_date, end_date, start_time, end_time,
                          duration_minutes, status, code, closed_at, selected_count, created_at, updated_at)


### PR DESCRIPTION
## 상세 내용

PollService에서 SystemTime을 사용하도록 변경해보았습니다!
지난 약속잡기 날짜 설정 #581  처럼, 우리가 객체지향적으로 코드를 잘 만들었기 때문에, 코드 변경점이 거의 없습니다.

PollService에서 LocalDateTime에 대한 의존을 제거했습니다!

PollService에서 SystemTime으로 바꾸니   pollService.closeAllBeforeNow() 테스트가 조금 깨지더라구요.
Test에서는 FakeSystemTime을 사용하다보니 data.sql에 있는 Poll 중에 삭제될 data가 없어서 테스트가 깨졌습니다.

따라서 data.sql에 Poll 데이터를 하나 추가했습니다.

Close #591 
