### PR TITLE
refactor: role history 에 query dsl 을 적용하고 복합 인덱스를 생성한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,6 +41,12 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
+    // query dsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
+    annotationProcessor 'javax.persistence:javax.persistence-api'
+    annotationProcessor 'javax.annotation:javax.annotation-api'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jpa'
+
     asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/backend/src/main/java/com/morak/back/role/domain/Role.java
+++ b/backend/src/main/java/com/morak/back/role/domain/Role.java
@@ -48,7 +48,7 @@ public class Role extends BaseRootEntity<Role> {
 
     public RoleHistory matchMembers(List<Long> memberIds, ShuffleStrategy strategy) {
         strategy.shuffle(memberIds);
-        RoleHistory roleHistory = new RoleHistory(LocalDateTime.now(), roleNames.match(memberIds));
+        RoleHistory roleHistory = new RoleHistory(LocalDateTime.now(), roleNames.match(memberIds), this.id);
         roleHistories.add(roleHistory);
         registerEvent(RoleHistoryEvent.from(roleHistory, teamCode.getCode()));
         return roleHistory;

--- a/backend/src/main/java/com/morak/back/role/domain/RoleEntityRepositoryImpl.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleEntityRepositoryImpl.java
@@ -3,10 +3,7 @@ package com.morak.back.role.domain;
 import static com.morak.back.role.domain.QRole.role;
 import static com.morak.back.role.domain.QRoleHistory.roleHistory;
 
-import com.querydsl.core.types.dsl.DateTemplate;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import javax.persistence.EntityManager;
@@ -38,12 +35,12 @@ public class RoleEntityRepositoryImpl implements RoleEntityRepository {
     }
 
     private Role findRoleWithGroupByAndOrderBy(String teamCode, Long roleId) {
-        List<Long> roleHistoryIds = findRoleHistoryIdsGroupByAndOrderBy(roleId);
+        List<Long> roleHistoryIds = findRoleHistoryIdsPerDate(roleId);
         List<RoleHistory> roleHistories = findAllRoleHistory(roleHistoryIds);
         return new Role(teamCode, null, new RoleHistories(roleHistories));
     }
 
-    private List<Long> findRoleHistoryIdsGroupByAndOrderBy(Long roleId) {
+    private List<Long> findRoleHistoryIdsPerDate(Long roleId) {
         return jpaQueryFactory.select(roleHistory.id.max())
                 .from(roleHistory)
                 .groupBy(roleHistory.date)

--- a/backend/src/main/java/com/morak/back/role/domain/RoleEntityRepositoryImpl.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleEntityRepositoryImpl.java
@@ -1,88 +1,56 @@
 package com.morak.back.role.domain;
 
-import com.morak.back.core.domain.Code;
-import java.util.ArrayList;
+import static com.morak.back.role.domain.QRole.role;
+import static com.morak.back.role.domain.QRoleHistory.roleHistory;
+
+import com.querydsl.core.types.dsl.DateTemplate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import org.springframework.dao.DataAccessException;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import javax.persistence.EntityManager;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class RoleEntityRepositoryImpl implements RoleEntityRepository {
 
-    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final JPAQueryFactory jpaQueryFactory;
 
-    public RoleEntityRepositoryImpl(NamedParameterJdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
+    public RoleEntityRepositoryImpl(EntityManager entityManager) {
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
     }
 
     @Override
     public Optional<Role> findWithOnlyHistoriesPerDate(String teamCode) {
-        Role role = queryRole(teamCode);
-        if (role == null) {
-            return Optional.empty();
-        }
-        RoleHistories roleHistories = findRoleHistories(role.getId());
+        RoleHistories roleHistories = findRoleHistories(teamCode);
         Role roleWithHistories = new Role(teamCode, null, roleHistories);
         return Optional.of(roleWithHistories);
     }
 
-    private Role queryRole(String teamCode) {
-        try {
-            return jdbcTemplate.queryForObject(
-                    "SELECT * FROM role r WHERE r.team_code = :teamCode",
-                    new MapSqlParameterSource("teamCode", teamCode),
-                    (rs, rowNum) -> new Role(rs.getLong("id"), Code.generate(ignored -> teamCode), null, null)
-            );
-        } catch (DataAccessException e) {
-            return null;
-        }
-    }
-
-    private RoleHistories findRoleHistories(Long roleId) {
-        List<RoleHistory> roleHistories = queryRoleHistories(roleId);
-        if (roleHistories.isEmpty()) {
-            return new RoleHistories(roleHistories);
-        }
-        Map<Long, RoleHistory> idsByHistory = roleHistories.stream()
-                .collect(Collectors.toMap(RoleHistory::getId, Function.identity()));
-        addMatchResults(idsByHistory);
+    private RoleHistories findRoleHistories(String teamCode) {
+        List<RoleHistory> roleHistories = jpaQueryFactory.selectFrom(roleHistory)
+                .join(roleHistory.matchResults).fetchJoin()
+                .where(roleHistory.id.in(
+                        JPAExpressions.select(roleHistory.id.max())
+                                .from(roleHistory)
+                                .groupBy(toLocalDate())
+                                .orderBy(toLocalDate().desc())
+                                .where(roleHistory.roleId.eq(
+                                        JPAExpressions.select(role.id)
+                                                .from(role)
+                                                .where(role.teamCode.code.eq(teamCode))
+                                ))
+                ))
+                .fetch();
         return new RoleHistories(roleHistories);
     }
 
-    private List<RoleHistory> queryRoleHistories(Long roleId) {
-        return jdbcTemplate.query(
-                "SELECT MAX(ID) id, MAX(rh.date_time) date_time "
-                        + "FROM role_history rh "
-                        + "WHERE rh.role_id = :roleId "
-                        + "GROUP BY cast(rh.date_time as DATE) "
-                        + "ORDER BY date_time desc",
-                new MapSqlParameterSource("roleId", roleId),
-                (rs, rowNum) -> new RoleHistory(
-                        rs.getLong("id"),
-                        rs.getTimestamp("date_time").toLocalDateTime(),
-                        new ArrayList<>()
-                )
-        );
-    }
-
-    private void addMatchResults(Map<Long, RoleHistory> idsByHistory) {
-        jdbcTemplate.query(
-                "SELECT * FROM role_match_result rms WHERE rms.role_history_id in (:ids)",
-                new MapSqlParameterSource("ids", idsByHistory.keySet()),
-                (rs, rowNum) -> {
-                    RoleMatchResult matchResult = new RoleMatchResult(
-                            new RoleName(rs.getString("role_name")),
-                            rs.getLong("member_id")
-                    );
-                    RoleHistory history = idsByHistory.get(rs.getLong("role_history_id"));
-                    history.getMatchResults().add(matchResult);
-                    return null;
-                });
+    private DateTemplate<LocalDate> toLocalDate() {
+        return Expressions.dateTemplate(
+                LocalDate.class,
+                "date({0})",
+                roleHistory.dateTime);
     }
 }

--- a/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
@@ -1,6 +1,7 @@
 package com.morak.back.role.domain;
 
 import com.morak.back.core.support.Generated;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +31,9 @@ public class RoleHistory implements Comparable<RoleHistory> {
     @Column(nullable = false)
     private LocalDateTime dateTime;
 
+    @Column(nullable = false)
+    private LocalDate date;
+
     @ElementCollection
     @CollectionTable(
             name = "role_match_result",
@@ -43,6 +47,7 @@ public class RoleHistory implements Comparable<RoleHistory> {
     public RoleHistory(LocalDateTime dateTime, List<RoleMatchResult> matchResults, Long roleId) {
         this.dateTime = dateTime;
         this.matchResults = matchResults;
+        this.date = LocalDate.from(dateTime);
         this.roleId = roleId;
     }
 

--- a/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
+++ b/backend/src/main/java/com/morak/back/role/domain/RoleHistory.java
@@ -37,9 +37,13 @@ public class RoleHistory implements Comparable<RoleHistory> {
     )
     private List<RoleMatchResult> matchResults = new ArrayList<>();
 
-    public RoleHistory(LocalDateTime dateTime, List<RoleMatchResult> matchResults) {
+    @Column(name = "role_id", insertable = false, updatable = false)
+    private Long roleId;
+
+    public RoleHistory(LocalDateTime dateTime, List<RoleMatchResult> matchResults, Long roleId) {
         this.dateTime = dateTime;
         this.matchResults = matchResults;
+        this.roleId = roleId;
     }
 
     @Override

--- a/backend/src/main/resources/data-local.sql
+++ b/backend/src/main/resources/data-local.sql
@@ -61,10 +61,10 @@ VALUES (1, 1, '2122-08-03T13:00:00', now());
 
 INSERT INTO role (id, team_code, created_at, updated_at) values (1, 'roletest', '2022-07-31T23:59:00', '2022-07-31T23:59:00');
 
-INSERT INTO role_history (date_time, role_id) values ('2022-07-31T23:59:00', 1);
-INSERT INTO role_history (date_time, role_id) values ('2022-07-31T23:59:05', 1);
-INSERT INTO role_history (date_time, role_id) values ('2022-08-01T10:12:00', 1);
-INSERT INTO role_history (date_time, role_id) values ('2022-08-02T10:23:00', 1);
+INSERT INTO role_history (date_time, date, role_id) values ('2022-07-31T23:59:00', '2022-07-31', 1);
+INSERT INTO role_history (date_time, date, role_id) values ('2022-07-31T23:59:05', '2022-07-31', 1);
+INSERT INTO role_history (date_time, date, role_id) values ('2022-08-01T10:12:00', '2022-08-01', 1);
+INSERT INTO role_history (date_time, date, role_id) values ('2022-08-02T10:23:00', '2022-08-02', 1);
 
 INSERT INTO role_match_result (role_history_id, member_id, role_name) values (1, 1, '데일리 마스터');
 INSERT INTO role_match_result (role_history_id, member_id, role_name) values (1, 2, '서기');

--- a/backend/src/main/resources/schema-dev.sql
+++ b/backend/src/main/resources/schema-dev.sql
@@ -168,6 +168,8 @@ CREATE TABLE role_history
     PRIMARY KEY (`id`)
 );
 
+create index role_history_index_role_id_date_desc on role_history (role_id, date desc);
+
 CREATE TABLE role_match_result
 (
     `role_history_id` BIGINT       NOT NULL,

--- a/backend/src/main/resources/schema-dev.sql
+++ b/backend/src/main/resources/schema-dev.sql
@@ -159,6 +159,15 @@ CREATE TABLE role
     PRIMARY KEY (`id`)
 );
 
+CREATE TABLE role_history
+(
+    `id`        BIGINT   NOT NULL AUTO_INCREMENT,
+    `date_time` DATETIME NOT NULL,
+    `date`      DATE     NOT NULL,
+    `role_id`   BIGINT   NOT NULL,
+    PRIMARY KEY (`id`)
+);
+
 CREATE TABLE role_match_result
 (
     `role_history_id` BIGINT       NOT NULL,
@@ -171,12 +180,4 @@ CREATE TABLE role_name
 (
     `role_id` BIGINT       NOT NULL,
     `name`    VARCHAR(255) NOT NULL
-);
-
-CREATE TABLE role_history
-(
-    `id`        BIGINT   NOT NULL AUTO_INCREMENT,
-    `date_time` DATETIME NOT NULL,
-    `role_id`   BIGINT   NOT NULL,
-    PRIMARY KEY (`id`)
 );

--- a/backend/src/main/resources/schema-local.sql
+++ b/backend/src/main/resources/schema-local.sql
@@ -168,6 +168,8 @@ CREATE TABLE role_history
     PRIMARY KEY (`id`)
 );
 
+create index role_history_index_role_id_date_desc on role_history (role_id, date desc);
+
 CREATE TABLE role_match_result
 (
     `role_history_id` BIGINT       NOT NULL,

--- a/backend/src/main/resources/schema-local.sql
+++ b/backend/src/main/resources/schema-local.sql
@@ -159,6 +159,15 @@ CREATE TABLE role
     PRIMARY KEY (`id`)
 );
 
+CREATE TABLE role_history
+(
+    `id`        BIGINT   NOT NULL AUTO_INCREMENT,
+    `date_time` DATETIME NOT NULL,
+    `date`      DATE     NOT NULL,
+    `role_id`   BIGINT   NOT NULL,
+    PRIMARY KEY (`id`)
+);
+
 CREATE TABLE role_match_result
 (
     `role_history_id` BIGINT       NOT NULL,
@@ -171,12 +180,4 @@ CREATE TABLE role_name
 (
     `role_id` BIGINT       NOT NULL,
     `name`    VARCHAR(255) NOT NULL
-);
-
-CREATE TABLE role_history
-(
-    `id`        BIGINT   NOT NULL AUTO_INCREMENT,
-    `date_time` DATETIME NOT NULL,
-    `role_id`   BIGINT   NOT NULL,
-    PRIMARY KEY (`id`)
 );

--- a/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
@@ -40,8 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-//@ServiceTest
-@SpringBootTest
+@ServiceTest
 class RoleServiceTest {
 
     private final MemberRepository memberRepository;
@@ -69,21 +68,21 @@ class RoleServiceTest {
     private Member member;
     private Team team;
 
-//    @BeforeEach
-//    void setup() {
-//        member = memberRepository.save(Member.builder()
-//                .oauthId("oauthmem")
-//                .name("박성우")
-//                .profileUrl("http://park-profile.com")
-//                .build());
-//
-//        team = teamRepository.save(Team.builder()
-//                .name("team")
-//                .code(Code.generate(length -> "abcd1234"))
-//                .build());
-//
-//        teamMemberRepository.save(new TeamMember(null, team, member));
-//    }
+    @BeforeEach
+    void setup() {
+        member = memberRepository.save(Member.builder()
+                .oauthId("oauthmem")
+                .name("박성우")
+                .profileUrl("http://park-profile.com")
+                .build());
+
+        team = teamRepository.save(Team.builder()
+                .name("team")
+                .code(Code.generate(length -> "abcd1234"))
+                .build());
+
+        teamMemberRepository.save(new TeamMember(null, team, member));
+    }
 
     @Test
     void 역할_이름_목록을_조회한다() {

--- a/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
+++ b/backend/src/test/java/com/morak/back/role/application/RoleServiceTest.java
@@ -9,6 +9,7 @@ import com.morak.back.auth.domain.MemberRepository;
 import com.morak.back.auth.exception.MemberNotFoundException;
 import com.morak.back.core.domain.Code;
 import com.morak.back.core.exception.CustomErrorCode;
+import com.morak.back.role.application.dto.HistoryResponse;
 import com.morak.back.role.application.dto.RoleNameResponses;
 import com.morak.back.role.application.dto.RoleResponse;
 import com.morak.back.role.application.dto.RolesResponse;
@@ -36,8 +37,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-@ServiceTest
+//@ServiceTest
+@SpringBootTest
 class RoleServiceTest {
 
     private final MemberRepository memberRepository;
@@ -65,21 +69,21 @@ class RoleServiceTest {
     private Member member;
     private Team team;
 
-    @BeforeEach
-    void setup() {
-        member = memberRepository.save(Member.builder()
-                .oauthId("oauthmem")
-                .name("박성우")
-                .profileUrl("http://park-profile.com")
-                .build());
-
-        team = teamRepository.save(Team.builder()
-                .name("team")
-                .code(Code.generate(length -> "abcd1234"))
-                .build());
-
-        teamMemberRepository.save(new TeamMember(null, team, member));
-    }
+//    @BeforeEach
+//    void setup() {
+//        member = memberRepository.save(Member.builder()
+//                .oauthId("oauthmem")
+//                .name("박성우")
+//                .profileUrl("http://park-profile.com")
+//                .build());
+//
+//        team = teamRepository.save(Team.builder()
+//                .name("team")
+//                .code(Code.generate(length -> "abcd1234"))
+//                .build());
+//
+//        teamMemberRepository.save(new TeamMember(null, team, member));
+//    }
 
     @Test
     void 역할_이름_목록을_조회한다() {
@@ -276,11 +280,13 @@ class RoleServiceTest {
         RoleHistories roleHistories = new RoleHistories();
 
         Long memberId = member.getId();
-        RoleHistory history1 = new RoleHistory(now, List.of(new RoleMatchResult(Role_데일리_마스터, memberId)));
-        RoleHistory history2 = new RoleHistory(now.plusSeconds(10), List.of(new RoleMatchResult(Role_서기, memberId)));
-        RoleHistory history3 = new RoleHistory(now.minusDays(1), List.of(new RoleMatchResult(Role_데일리_마스터, memberId)));
+        RoleHistory history1 = new RoleHistory(now, List.of(new RoleMatchResult(Role_데일리_마스터, memberId)), null);
+        RoleHistory history2 = new RoleHistory(now.plusSeconds(10), List.of(new RoleMatchResult(Role_서기, memberId)),
+                null);
+        RoleHistory history3 = new RoleHistory(now.minusDays(1), List.of(new RoleMatchResult(Role_데일리_마스터, memberId)),
+                null);
         RoleHistory history4 = new RoleHistory(now.minusDays(1).plusSeconds(10),
-                List.of(new RoleMatchResult(Role_서기, memberId)));
+                List.of(new RoleMatchResult(Role_서기, memberId)), null);
 
         roleHistories.add(history1);
         roleHistories.add(history2);

--- a/backend/src/test/java/com/morak/back/role/domain/RoleEntityRepositoryTest.java
+++ b/backend/src/test/java/com/morak/back/role/domain/RoleEntityRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.morak.back.support.RepositoryTest;
 import java.util.Optional;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,9 +20,9 @@ class RoleEntityRepositoryTest {
     private RoleEntityRepository roleEntityRepository;
 
     @Autowired
-    public RoleEntityRepositoryTest(RoleRepository roleRepository, NamedParameterJdbcTemplate jdbcTemplate) {
+    public RoleEntityRepositoryTest(RoleRepository roleRepository, EntityManager entityManager) {
         this.roleRepository = roleRepository;
-        this.roleEntityRepository = new RoleEntityRepositoryImpl(jdbcTemplate);
+        this.roleEntityRepository = new RoleEntityRepositoryImpl(entityManager);
     }
 
     @Test

--- a/backend/src/test/java/com/morak/back/role/domain/RoleHistoriesTest.java
+++ b/backend/src/test/java/com/morak/back/role/domain/RoleHistoriesTest.java
@@ -17,10 +17,11 @@ class RoleHistoriesTest {
         RoleName 서기 = new RoleName("서기");
         RoleHistories roleHistories = new RoleHistories();
 
-        RoleHistory history1 = new RoleHistory(now, List.of(new RoleMatchResult(데일리_마스터, 1L)));
-        RoleHistory history2 = new RoleHistory(now.plusSeconds(10), List.of(new RoleMatchResult(서기, 2L)));
-        RoleHistory history3 = new RoleHistory(now.minusDays(1), List.of(new RoleMatchResult(데일리_마스터, 2L)));
-        RoleHistory history4 = new RoleHistory(now.minusDays(1).plusSeconds(10), List.of(new RoleMatchResult(서기, 1L)));
+        RoleHistory history1 = new RoleHistory(now, List.of(new RoleMatchResult(데일리_마스터, 1L)), null);
+        RoleHistory history2 = new RoleHistory(now.plusSeconds(10), List.of(new RoleMatchResult(서기, 2L)), null);
+        RoleHistory history3 = new RoleHistory(now.minusDays(1), List.of(new RoleMatchResult(데일리_마스터, 2L)), null);
+        RoleHistory history4 = new RoleHistory(now.minusDays(1).plusSeconds(10), List.of(new RoleMatchResult(서기, 1L)),
+                null);
 
         roleHistories.add(history1);
         roleHistories.add(history2);

--- a/backend/src/test/java/com/morak/back/role/domain/RoleHistoryTest.java
+++ b/backend/src/test/java/com/morak/back/role/domain/RoleHistoryTest.java
@@ -12,9 +12,9 @@ class RoleHistoryTest {
     @Test
     void RoleHistory는_dateTime에_따라_크기_비교가_된다() {
         // given
-        RoleHistory roleHistoryA = new RoleHistory(LocalDateTime.now(), new ArrayList<>());
-        RoleHistory roleHistoryB = new RoleHistory(LocalDateTime.now().plusDays(1), new ArrayList<>());
-        RoleHistory roleHistoryC = new RoleHistory(LocalDateTime.now().plusDays(2), new ArrayList<>());
+        RoleHistory roleHistoryA = new RoleHistory(LocalDateTime.now(), new ArrayList<>(), 1L);
+        RoleHistory roleHistoryB = new RoleHistory(LocalDateTime.now().plusDays(1), new ArrayList<>(), 1L);
+        RoleHistory roleHistoryC = new RoleHistory(LocalDateTime.now().plusDays(2), new ArrayList<>(), 1L);
 
         // when & then
         assertAll(

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -15,9 +15,6 @@ spring:
         batch_fetch_style: padded
         default_batch_fetch_size: 100
         format_sql: true
-  sql:
-    init:
-      mode: always
   mvc:
     throw-exception-if-no-handler-found: true
   web:
@@ -63,6 +60,9 @@ spring:
   h2:
     console:
       enabled: true
+  sql:
+    init:
+      mode: always
 
 ---
 
@@ -73,8 +73,16 @@ spring:
     activate:
       on-profile: performance
   datasource: # H2 인 경우 주석을 해제한다.
-    url: jdbc:mysql://localhost:33306/morak?characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:h2:~/perform;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: sa
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+  sql:
+    init:
+      mode: always
+
 #  datasource: # Docker 인 경우 주석을 해제한다.
 #    url: jdbc:mysql://localhost:33306/morak?characterEncoding=UTF-8&serverTimezone=UTC
 #    username: root

--- a/backend/src/test/resources/data.sql
+++ b/backend/src/test/resources/data.sql
@@ -45,10 +45,10 @@ VALUES (1, 'https://slack.webhook.com/', now(), now());
 
 INSERT INTO role (id, team_code, created_at, updated_at) values (1, 'roletest', '2022-07-31T23:59:00', '2022-07-31T23:59:00');
 
-INSERT INTO role_history (id, date_time, role_id) values (1, '2022-07-31T23:59:00', 1);
-INSERT INTO role_history (id, date_time, role_id) values (2, '2022-07-31T23:59:05', 1);
-INSERT INTO role_history (id, date_time, role_id) values (3, '2022-08-01T10:12:00', 1);
-INSERT INTO role_history (id, date_time, role_id) values (4, '2022-08-02T10:23:00', 1);
+INSERT INTO role_history (id, date_time, date, role_id) values (1, '2022-07-31T23:59:00', '2022-07-31', 1);
+INSERT INTO role_history (id, date_time, date, role_id) values (2, '2022-07-31T23:59:05', '2022-07-31', 1);
+INSERT INTO role_history (id, date_time, date, role_id) values (3, '2022-08-01T10:12:00', '2022-08-01', 1);
+INSERT INTO role_history (id, date_time, date, role_id) values (4, '2022-08-02T10:23:00', '2022-08-02', 1);
 
 INSERT INTO role_match_result (role_history_id, member_id, role_name) values (1, 1, '데일리 마스터');
 INSERT INTO role_match_result (role_history_id, member_id, role_name) values (1, 2, '서기');

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -177,6 +177,7 @@ CREATE TABLE role_history
 (
     `id`        BIGINT   NOT NULL AUTO_INCREMENT,
     `date_time` DATETIME NOT NULL,
+    `date`      DATE     NOT NULL,
     `role_id`   BIGINT   NOT NULL,
     PRIMARY KEY (`id`)
 );

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -159,6 +159,17 @@ CREATE TABLE role
     PRIMARY KEY (`id`)
 );
 
+CREATE TABLE role_history
+(
+    `id`        BIGINT   NOT NULL AUTO_INCREMENT,
+    `date_time` DATETIME NOT NULL,
+    `date`      DATE     NOT NULL,
+    `role_id`   BIGINT   NOT NULL,
+    PRIMARY KEY (`id`)
+);
+
+create index role_history_index_role_id_date_desc on role_history (role_id, date desc);
+
 CREATE TABLE role_match_result
 (
     `role_history_id` BIGINT       NOT NULL,
@@ -171,13 +182,4 @@ CREATE TABLE role_name
 (
     `role_id` BIGINT       NOT NULL,
     `name`    VARCHAR(255) NOT NULL
-);
-
-CREATE TABLE role_history
-(
-    `id`        BIGINT   NOT NULL AUTO_INCREMENT,
-    `date_time` DATETIME NOT NULL,
-    `date`      DATE     NOT NULL,
-    `role_id`   BIGINT   NOT NULL,
-    PRIMARY KEY (`id`)
 );


### PR DESCRIPTION
Close #608 

## 배경 지식

> query dsl

- 자바로 작성할 수 있기때문에, 문법 오류를 컴파일 시점에 잡을 수 있다.
- 문자열로 쿼리를 작성하면 오류를 런타임 시점에 발견할 수 밖에 없다.
- 자동 완성의 도움을 받을 수 있다.
- 동적 쿼리 문제를 해결할 수 있다.

> 복합 인덱스
- 복합 인덱스는 여러 컬럼을 묶어서 인덱스로 저장한다.
- 조건절에 여러 컬럼이 사용되거나 조건절, 그룹화에 사용되는 컬럼이 다른 경우에 인덱스를 탈 수 있도록 복합 인덱스를 설정한다.
- 순서가 존재하여 이를 잘 숙지해야 한다.

> 커버링 인덱스
- 조회를 위해 사용되는 컬럼(조회 프로젝션, 조건절, 그룹화 등)이 모두 인덱스로 등록되어 있을 때 빠르게 조회가 가능한 인덱스이다.
- Inno DB의 세컨더리 인덱스 저장 구조는 리프 노드에 데이터의 주소가 아닌 PK 값이 저장되어 있다.
- 이로 인해 데이터에 직접 접근하지 않고 인덱스만으로 조회가 가능하다.

## 상세 내용

1. role id 를 추가하고 query dsl 을 적용

- 연관 관계에 있는 role 객체를 간접 참조로 하는 role id 를 추가하였다.
- 가독성과 타입 안정성 측면에서 개선하였다.
- 영속성 컨텍스트 사용이 가능하다.

```java

@Repository
public class RoleEntityRepositoryImpl implements RoleEntityRepository {

    private List<Long> findRoleHistoryIdsGroupByAndOrderBy(Long roleId) {
        return jpaQueryFactory.select(roleHistory.id.max())
                .from(roleHistory)
                .groupBy(roleHistory.date)
                .orderBy(roleHistory.date.desc())
                .where(roleHistory.roleId.eq(roleId))
                .fetch();
    }

    private List<RoleHistory> findAllRoleHistory(List<Long> ids) {
        return jpaQueryFactory.selectFrom(roleHistory)
                .from(roleHistory)
                .where(roleHistory.id.in(ids))
                .fetch();
    }
}
```

2. date 컬럼을 추가하고 복합 인덱스를 생성하여 커버링 인덱스를 적용

![image](https://user-images.githubusercontent.com/42317507/229721432-46192c4a-ab85-4676-a312-1e8bbec499bd.png)

- 기존에 date 로 변환하는 로직에서 date 열을 추가하여 인덱스를 탈 수 있도록 하였다.
- where 조건절, 그룹화, 정렬, 조회 프로젝션에 사용되는 컬럼(id, role id, date)이 모두 인덱스로 등록되어 커버링 인덱스가 가능하도록 하였다.
- MySQL 8 부터 적용되는 역순 인덱스를 적용하였다.
