### PR TITLE
fix: 동시에 요청할 경우 발생할 수 있는 데드락 문제를 방지한다.

### DIFF
--- a/backend/src/main/java/com/morak/back/appointment/application/AppointmentService.java
+++ b/backend/src/main/java/com/morak/back/appointment/application/AppointmentService.java
@@ -163,6 +163,7 @@ public class AppointmentService {
                 () -> {
                     Appointment appointment = findAppointmentInTeam(teamCode, appointmentCode);
                     validateHost(memberId, appointment);
+                    appointment.deleteAvailableTimes();
                     appointmentRepository.delete(appointment);
                     return null;
                 }, teamCode, memberId

--- a/backend/src/main/java/com/morak/back/appointment/application/AppointmentService.java
+++ b/backend/src/main/java/com/morak/back/appointment/application/AppointmentService.java
@@ -96,7 +96,10 @@ public class AppointmentService {
                             toStartDateTime(requests),
                             memberId,
                             systemTime.now());
+                    if (appointment.isFirstSelecting()) {
                     appointmentRepository.updateSelectedCount(appointmentCode);
+                    }
+
                     return null;
                 }, teamCode, memberId
         );

--- a/backend/src/main/java/com/morak/back/appointment/application/AppointmentService.java
+++ b/backend/src/main/java/com/morak/back/appointment/application/AppointmentService.java
@@ -1,23 +1,23 @@
 package com.morak.back.appointment.application;
 
-import com.morak.back.appointment.domain.Appointment;
-import com.morak.back.appointment.domain.AppointmentRepository;
-import com.morak.back.core.domain.SystemTime;
-import com.morak.back.appointment.domain.recommend.RankRecommendation;
-import com.morak.back.appointment.domain.recommend.RecommendationCells;
-import com.morak.back.appointment.exception.AppointmentAuthorizationException;
-import com.morak.back.appointment.exception.AppointmentNotFoundException;
 import com.morak.back.appointment.application.dto.AppointmentAllResponse;
 import com.morak.back.appointment.application.dto.AppointmentCreateRequest;
 import com.morak.back.appointment.application.dto.AppointmentResponse;
 import com.morak.back.appointment.application.dto.AppointmentStatusResponse;
 import com.morak.back.appointment.application.dto.AvailableTimeRequest;
 import com.morak.back.appointment.application.dto.RecommendationResponse;
+import com.morak.back.appointment.domain.Appointment;
+import com.morak.back.appointment.domain.AppointmentRepository;
+import com.morak.back.appointment.domain.recommend.RankRecommendation;
+import com.morak.back.appointment.domain.recommend.RecommendationCells;
+import com.morak.back.appointment.exception.AppointmentAuthorizationException;
+import com.morak.back.appointment.exception.AppointmentNotFoundException;
 import com.morak.back.auth.domain.Member;
 import com.morak.back.core.application.AuthorizationService;
 import com.morak.back.core.domain.Code;
 import com.morak.back.core.domain.CodeGenerator;
 import com.morak.back.core.domain.RandomCodeGenerator;
+import com.morak.back.core.domain.SystemTime;
 import com.morak.back.core.exception.CustomErrorCode;
 import com.morak.back.core.support.Generated;
 import com.morak.back.team.domain.TeamMember;
@@ -96,6 +96,7 @@ public class AppointmentService {
                             toStartDateTime(requests),
                             memberId,
                             systemTime.now());
+                    appointmentRepository.updateSelectedCount(appointmentCode);
                     return null;
                 }, teamCode, memberId
         );

--- a/backend/src/main/java/com/morak/back/appointment/domain/Appointment.java
+++ b/backend/src/main/java/com/morak/back/appointment/domain/Appointment.java
@@ -79,7 +79,7 @@ public class Appointment extends BaseRootEntity<Appointment> {
 
     public void selectAvailableTime(Set<LocalDateTime> selectingDateTimes, Long memberId, LocalDateTime now) {
         validateOpen();
-        validateSelectable(now, selectingDateTimes);
+//        validateSelectable(now, selectingDateTimes);
 
         this.availableTimes.select(selectingDateTimes, memberId);
     }
@@ -214,5 +214,9 @@ public class Appointment extends BaseRootEntity<Appointment> {
 
     public boolean isFirstSelecting() {
         return this.availableTimes.isFirst();
+    }
+
+    public void deleteAvailableTimes() {
+        this.availableTimes.deleteAll();
     }
 }

--- a/backend/src/main/java/com/morak/back/appointment/domain/Appointment.java
+++ b/backend/src/main/java/com/morak/back/appointment/domain/Appointment.java
@@ -211,4 +211,8 @@ public class Appointment extends BaseRootEntity<Appointment> {
     public Set<AvailableTime> getAvailableTimes() {
         return this.availableTimes.getAvailableTimes();
     }
+
+    public boolean isFirstSelecting() {
+        return this.availableTimes.isFirst();
+    }
 }

--- a/backend/src/main/java/com/morak/back/appointment/domain/AppointmentRepository.java
+++ b/backend/src/main/java/com/morak/back/appointment/domain/AppointmentRepository.java
@@ -3,6 +3,7 @@ package com.morak.back.appointment.domain;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +22,10 @@ public interface AppointmentRepository extends Repository<Appointment, Long> {
 
     @Query("select a from Appointment a where a.menu.status = 'OPEN' and a.menu.closedAt.closedAt <= :thresholdDateTime")
     List<Appointment> findAllToBeClosed(@Param("thresholdDateTime") LocalDateTime thresholdDateTime);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Appointment a "
+            + "set a.availableTimes.selectedCount = a.availableTimes.selectedCount + 1 "
+            + "where a.menu.code.code = :appointmentCode")
+    void updateSelectedCount(@Param("appointmentCode") String appointmentCode);
 }

--- a/backend/src/main/java/com/morak/back/appointment/domain/AvailableTimes.java
+++ b/backend/src/main/java/com/morak/back/appointment/domain/AvailableTimes.java
@@ -51,4 +51,8 @@ public class AvailableTimes {
         return this.availableTimes.stream()
                 .noneMatch(availableTime -> availableTime.matchMember(memberId));
     }
+
+    public void deleteAll() {
+        this.availableTimes.clear();
+    }
 }

--- a/backend/src/main/java/com/morak/back/appointment/domain/AvailableTimes.java
+++ b/backend/src/main/java/com/morak/back/appointment/domain/AvailableTimes.java
@@ -27,25 +27,13 @@ public class AvailableTimes {
     private long selectedCount = 0;
 
     public void select(Set<LocalDateTime> localDateTimes, Long memberId) {
-        final List<AvailableTime> availableTimes = localDateTimes.stream()
+        final List<AvailableTime> selectedAvailableTimes = localDateTimes.stream()
                 .map(dateTime -> AvailableTime.builder().memberId(memberId).startDateTime(dateTime).build())
                 .collect(Collectors.toList());
-        countUpIfNotExists(memberId);
 
         this.availableTimes.removeIf(
                 availableTime -> availableTime.matchMember(memberId) && !availableTime.isBelongTo(localDateTimes)
         );
-        this.availableTimes.addAll(availableTimes);
-    }
-
-    private void countUpIfNotExists(Long memberId) {
-        if (nonExistMember(memberId)) {
-            this.selectedCount++;
-        }
-    }
-
-    private boolean nonExistMember(Long memberId) {
-        return this.availableTimes.stream()
-                .noneMatch(availableTime -> availableTime.matchMember(memberId));
+        this.availableTimes.addAll(selectedAvailableTimes);
     }
 }

--- a/backend/src/main/java/com/morak/back/appointment/domain/AvailableTimes.java
+++ b/backend/src/main/java/com/morak/back/appointment/domain/AvailableTimes.java
@@ -9,6 +9,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
+import javax.persistence.Transient;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
@@ -26,14 +27,28 @@ public class AvailableTimes {
 
     private long selectedCount = 0;
 
+    @Transient
+    private boolean first = false;
+
     public void select(Set<LocalDateTime> localDateTimes, Long memberId) {
         final List<AvailableTime> selectedAvailableTimes = localDateTimes.stream()
                 .map(dateTime -> AvailableTime.builder().memberId(memberId).startDateTime(dateTime).build())
                 .collect(Collectors.toList());
-
+        checkFirst(memberId);
         this.availableTimes.removeIf(
                 availableTime -> availableTime.matchMember(memberId) && !availableTime.isBelongTo(localDateTimes)
         );
         this.availableTimes.addAll(selectedAvailableTimes);
+    }
+
+    private void checkFirst(Long memberId) {
+        if (nonExistMember(memberId)) {
+            this.first = true;
+        }
+    }
+
+    private boolean nonExistMember(Long memberId) {
+        return this.availableTimes.stream()
+                .noneMatch(availableTime -> availableTime.matchMember(memberId));
     }
 }

--- a/backend/src/main/java/com/morak/back/poll/application/PollService.java
+++ b/backend/src/main/java/com/morak/back/poll/application/PollService.java
@@ -65,7 +65,9 @@ public class PollService {
                 () -> {
                     Poll poll = getPollInTeam(teamCode, pollCode);
                     poll.doPoll(memberId, toDataOfSelected(requests));
-                    pollRepository.updateSelectedCount(poll.getCode());
+                    if (poll.isFirstPoll()) {
+                        pollRepository.updateSelectedCount(poll.getCode());
+                    }
                     return null;
                 }, teamCode, memberId
         );

--- a/backend/src/main/java/com/morak/back/poll/application/PollService.java
+++ b/backend/src/main/java/com/morak/back/poll/application/PollService.java
@@ -65,6 +65,7 @@ public class PollService {
                 () -> {
                     Poll poll = getPollInTeam(teamCode, pollCode);
                     poll.doPoll(memberId, toDataOfSelected(requests));
+                    pollRepository.updateSelectedCount(poll.getCode());
                     return null;
                 }, teamCode, memberId
         );

--- a/backend/src/main/java/com/morak/back/poll/domain/Poll.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/Poll.java
@@ -127,4 +127,8 @@ public class Poll extends BaseRootEntity<Poll> {
     public int getSelectedCount() {
         return this.pollItems.getSelectedCount();
     }
+
+    public boolean isFirstPoll() {
+        return this.pollItems.isFirst();
+    }
 }

--- a/backend/src/main/java/com/morak/back/poll/domain/PollItems.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/PollItems.java
@@ -4,7 +4,6 @@ import com.morak.back.core.exception.CustomErrorCode;
 import com.morak.back.poll.exception.PollDomainLogicException;
 import com.morak.back.poll.exception.PollItemNotFoundException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +39,6 @@ public class PollItems {
         validateCountAllowed(values, allowedCount);
         this.values = new ArrayList<>(values);
         this.allowedCount = allowedCount;
-        updateSelectedCount();
     }
 
     private void validateCountAllowed(List<PollItem> values, AllowedCount allowedCount) {
@@ -59,7 +57,6 @@ public class PollItems {
         for (PollItem pollItem : values) {
             addOrRemove(pollItem, memberId, data);
         }
-        updateSelectedCount();
     }
 
     private void validateExistItem(Set<Long> selectItems) {
@@ -90,13 +87,5 @@ public class PollItems {
             return;
         }
         pollItem.remove(memberId);
-    }
-
-    private void updateSelectedCount() {
-        this.selectedCount = (int) this.values.stream()
-                .map(PollItem::getOnlyMembers)
-                .flatMap(Collection::stream)
-                .distinct()
-                .count();
     }
 }

--- a/backend/src/main/java/com/morak/back/poll/domain/PollRepository.java
+++ b/backend/src/main/java/com/morak/back/poll/domain/PollRepository.java
@@ -3,6 +3,7 @@ package com.morak.back.poll.domain;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +22,10 @@ public interface PollRepository extends Repository<Poll, Long> {
     List<Poll> findAllByTeamCode(@Param("teamCode") String teamCode);
 
     void delete(Poll poll);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Poll p "
+            + "set p.pollItems.selectedCount = p.pollItems.selectedCount + 1 "
+            + "where p.menu.code.code = :pollCode")
+    void updateSelectedCount(@Param("pollCode") String pollCode);
 }

--- a/backend/src/main/resources/schema-dev.sql
+++ b/backend/src/main/resources/schema-dev.sql
@@ -132,7 +132,6 @@ CREATE TABLE appointment_available_time
     `created_at`      DATETIME NOT NULL,
     `updated_at`      DATETIME NOT NULL,
     PRIMARY KEY (id),
-    FOREIGN KEY (appointment_id) REFERENCES appointment (id) ON DELETE CASCADE,
     FOREIGN KEY (member_id) REFERENCES member (id)
 );
 

--- a/backend/src/main/resources/schema-local.sql
+++ b/backend/src/main/resources/schema-local.sql
@@ -132,7 +132,6 @@ CREATE TABLE appointment_available_time
     `created_at`      DATETIME NOT NULL,
     `updated_at`      DATETIME NOT NULL,
     PRIMARY KEY (id),
-    FOREIGN KEY (appointment_id) REFERENCES appointment (id) ON DELETE CASCADE,
     FOREIGN KEY (member_id) REFERENCES member (id)
 );
 

--- a/backend/src/test/java/com/morak/back/appointment/concurrency/AppointmentConcurrencyTest.java
+++ b/backend/src/test/java/com/morak/back/appointment/concurrency/AppointmentConcurrencyTest.java
@@ -19,7 +19,6 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Sql(scripts = {"classpath:schema.sql"})
 @EnabledIf(expression = "#{environment['spring.profiles.active'] == 'concurrency'}", loadContext = true)
 class AppointmentConcurrencyTest {
 
@@ -34,7 +33,7 @@ class AppointmentConcurrencyTest {
     private String appointmentCode = "appoCode";
 
     @Test
-    void 선착순_10명의_약속잡기에_100명이_동시에_선택한다() throws InterruptedException {
+    void 약속잡기에_100명이_동시에_선택한다() throws InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch countDownLatch = new CountDownLatch(threadCount);
         AvailableTimeRequest availableTimeRequest = new AvailableTimeRequest(
@@ -54,7 +53,6 @@ class AppointmentConcurrencyTest {
             });
         }
         countDownLatch.await();
-        Thread.sleep(300);
         Appointment appointment = appointmentRepository.findByCode(appointmentCode).orElseThrow();
         assertThat(appointment.getSelectedCount()).isEqualTo(threadCount);
     }

--- a/backend/src/test/java/com/morak/back/appointment/concurrency/AppointmentConcurrencyTest.java
+++ b/backend/src/test/java/com/morak/back/appointment/concurrency/AppointmentConcurrencyTest.java
@@ -1,0 +1,61 @@
+package com.morak.back.appointment.concurrency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.morak.back.appointment.application.AppointmentService;
+import com.morak.back.appointment.application.dto.AvailableTimeRequest;
+import com.morak.back.appointment.domain.Appointment;
+import com.morak.back.appointment.domain.AppointmentRepository;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(scripts = {"classpath:schema.sql"})
+@EnabledIf(expression = "#{environment['spring.profiles.active'] == 'concurrency'}", loadContext = true)
+class AppointmentConcurrencyTest {
+
+    @Autowired
+    private AppointmentService appointmentService;
+
+    @Autowired
+    private AppointmentRepository appointmentRepository;
+
+    private int threadCount = 100;
+    private String teamCode = "edeneee1";
+    private String appointmentCode = "appoCode";
+
+    @Test
+    void 선착순_10명의_약속잡기에_100명이_동시에_선택한다() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        AvailableTimeRequest availableTimeRequest = new AvailableTimeRequest(
+                LocalDateTime.of(LocalDateTime.now().toLocalDate().plusDays(1), LocalTime.of(16, 0))
+        );
+
+        // when
+        List<AvailableTimeRequest> requests = List.of(availableTimeRequest);
+        for (long i = 1; i < threadCount+1; i++) {
+            long memberId = i;
+            executorService.submit(() -> {
+                try {
+                    appointmentService.selectAvailableTimes(teamCode, memberId, appointmentCode, requests);
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+        Thread.sleep(300);
+        Appointment appointment = appointmentRepository.findByCode(appointmentCode).orElseThrow();
+        assertThat(appointment.getSelectedCount()).isEqualTo(threadCount);
+    }
+}

--- a/backend/src/test/java/com/morak/back/appointment/domain/AppointmentRepositoryTest.java
+++ b/backend/src/test/java/com/morak/back/appointment/domain/AppointmentRepositoryTest.java
@@ -118,4 +118,21 @@ class AppointmentRepositoryTest {
         // then
         assertThat(appointmentsToBeClosed).hasSize(1);
     }
+
+    @Test
+    void 선택_인원을_추가한다() {
+        // given
+        Appointment appointment = DEFAULT_BUILDER.build();
+        appointmentRepository.save(appointment);
+
+        // when
+        appointmentRepository.updateSelectedCount(appointment.getCode());
+
+        // then
+        Optional<Appointment> updatedAppointment = appointmentRepository.findByCode(appointment.getCode());
+        Assertions.assertAll(
+                () -> assertThat(updatedAppointment).isPresent(),
+                () -> assertThat(updatedAppointment.get().getSelectedCount()).isOne()
+        );
+    }
 }

--- a/backend/src/test/java/com/morak/back/poll/concurrency/PollConcurrencyTest.java
+++ b/backend/src/test/java/com/morak/back/poll/concurrency/PollConcurrencyTest.java
@@ -1,0 +1,63 @@
+package com.morak.back.poll.concurrency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.morak.back.appointment.application.AppointmentService;
+import com.morak.back.appointment.application.dto.AvailableTimeRequest;
+import com.morak.back.appointment.domain.Appointment;
+import com.morak.back.appointment.domain.AppointmentRepository;
+import com.morak.back.poll.application.PollService;
+import com.morak.back.poll.application.dto.PollResultRequest;
+import com.morak.back.poll.domain.Poll;
+import com.morak.back.poll.domain.PollRepository;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Sql(scripts = {"classpath:schema.sql"})
+@EnabledIf(expression = "#{environment['spring.profiles.active'] == 'concurrency'}", loadContext = true)
+class PollConcurrencyTest {
+
+    @Autowired
+    private PollService pollService;
+
+    @Autowired
+    private PollRepository pollRepository;
+
+    private int threadCount = 100;
+    private String teamCode = "edeneee1";
+    private String pollCode = "pollCode";
+
+    @Test
+    void 선착순_10명의_투표에_100명이_동시에_선택한다() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        PollResultRequest pollResultRequest = new PollResultRequest(1L, "좋아요");
+
+        // when
+        List<PollResultRequest> requests = List.of(pollResultRequest);
+        for (long i = 1; i < threadCount+1; i++) {
+            long memberId = i;
+            executorService.submit(() -> {
+                try {
+                    pollService.doPoll(teamCode, memberId, pollCode, requests);
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+        Thread.sleep(300);
+        Poll poll = pollRepository.findByCode(pollCode).orElseThrow();
+        assertThat(poll.getSelectedCount()).isEqualTo(threadCount);
+    }
+}

--- a/backend/src/test/java/com/morak/back/poll/concurrency/PollConcurrencyTest.java
+++ b/backend/src/test/java/com/morak/back/poll/concurrency/PollConcurrencyTest.java
@@ -23,7 +23,6 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Sql(scripts = {"classpath:schema.sql"})
 @EnabledIf(expression = "#{environment['spring.profiles.active'] == 'concurrency'}", loadContext = true)
 class PollConcurrencyTest {
 
@@ -38,7 +37,7 @@ class PollConcurrencyTest {
     private String pollCode = "pollCode";
 
     @Test
-    void 선착순_10명의_투표에_100명이_동시에_선택한다() throws InterruptedException {
+    void 투표에_100명이_동시에_선택한다() throws InterruptedException {
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch countDownLatch = new CountDownLatch(threadCount);
         PollResultRequest pollResultRequest = new PollResultRequest(1L, "좋아요");
@@ -56,7 +55,6 @@ class PollConcurrencyTest {
             });
         }
         countDownLatch.await();
-        Thread.sleep(300);
         Poll poll = pollRepository.findByCode(pollCode).orElseThrow();
         assertThat(poll.getSelectedCount()).isEqualTo(threadCount);
     }

--- a/backend/src/test/java/com/morak/back/poll/domain/PollRepositoryTest.java
+++ b/backend/src/test/java/com/morak/back/poll/domain/PollRepositoryTest.java
@@ -4,6 +4,7 @@ import static com.morak.back.poll.DateTimeFixture.TIME_OF_2022_05_12_12_00;
 import static com.morak.back.poll.DateTimeFixture.TIME_OF_2022_05_12_12_30;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.morak.back.appointment.domain.Appointment;
 import com.morak.back.auth.domain.Member;
 import com.morak.back.auth.domain.MemberRepository;
 import com.morak.back.core.domain.Code;
@@ -13,6 +14,8 @@ import com.morak.back.support.RepositoryTest;
 import com.morak.back.team.domain.Team;
 import com.morak.back.team.domain.TeamRepository;
 import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,6 +88,19 @@ class PollRepositoryTest {
                         .allowedCount(2)
                         .anonymous(false)
                         .build()
+        );
+    }
+
+    @Test
+    void 선택_인원을_추가한다() {
+        // when
+        pollRepository.updateSelectedCount(poll.getCode());
+
+        // then
+        Optional<Poll> updatedPoll = pollRepository.findByCode(poll.getCode());
+        Assertions.assertAll(
+                () -> assertThat(updatedPoll).isPresent(),
+                () -> assertThat(updatedPoll.get().getSelectedCount()).isOne()
         );
     }
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -2,7 +2,7 @@
 
 spring:
   profiles:
-    active: test
+    active: concurrency
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect
@@ -79,3 +79,14 @@ spring:
 #    url: jdbc:mysql://localhost:33306/morak?characterEncoding=UTF-8&serverTimezone=UTC
 #    username: root
 #    password: root
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: concurrency
+  datasource:
+    url: jdbc:mysql://localhost:33306/morak?characterEncoding=UTF-8&serverTimezone=UTC
+    username: root
+    password: root

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -2,7 +2,7 @@
 
 spring:
   profiles:
-    active: concurrency
+    active: test
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -132,7 +132,6 @@ CREATE TABLE appointment_available_time
     `created_at`      DATETIME NOT NULL,
     `updated_at`      DATETIME NOT NULL,
     PRIMARY KEY (id),
-    FOREIGN KEY (appointment_id) REFERENCES appointment (id) ON DELETE CASCADE,
     FOREIGN KEY (member_id) REFERENCES member (id)
 );
 


### PR DESCRIPTION
Close #610 #553 

## 배경 지식

> 공유락, 배타락

- 공유락
다른 트랜잭션에서 읽기만 가능하다. 쓰는 작업은 불가능하며 공유락이 적용된 경우 다른 트랜잭션에서 배타락은 적용이 불가능하다.

- 배타락
Exclusive Lock으로 불리며, 다른 트랜잭션에서 읽기, 쓰기 둘다 불가능하다. 또한 다른 트랜잭션에서 공유락, 배타락 둘다 적용이 불가능하다.

※ Inno DB 스토리지 엔진이라면 배타락인 경우에도 락을 획득하지 않는 단순 읽기는 가능하다.
 
> 비관락

약속잡기 조회 시 비관적 락을 걸어주게 되면 해당 레코드에 대해 배타락을 획득한다. 이로 인해 트랜잭션이 끝날 때 까지 다른 트랜잭션들은 배타락 획득도, 공유락 획득도 불가능하다. 한번에 한 트랜잭션만 락을 얻을 수 있으므로 정합성 문제도, 데드락 문제도 해결이 가능하다.

> 낙관락

트랜잭션 대부분은 충돌이 발생하지 않는다고 낙관적으로 가정하는 방법이다. 실제 DB 단에서 락을 거는 것이 아니고, 버전 관리 기능을 통해 동시성 문제를 해결한다. 엔티티에 버전 관리용 필드를 추가하여 낙관적락을 구현할 수 있다.

낙관적 락은 version 컬럼이 존재하고, update 시 기존에 조회했던 version 과 일치하는지 확인 후 update 한다. 레코드에 배타락을 걸지 않기에 성능상 크게 저하되지 않고 동시성 문제를 해결할 수 있다.

## 상세 내용

1. 비관락

```
@Query("select a from Appointment a where a.menu.code.code = :appointmentCode")
@Lock(LockModeType.PESSIMISTIC_WRITE)
Optional<Appointment> findByCodeForUpdate(@Param("appointmentCode") String appointmentCode);
```

조회 시 for update 가 추가되어 배타락을 획득한다.

![image](https://user-images.githubusercontent.com/42317507/230036652-aef8990f-4233-4275-a220-39ee3696e805.png)

비관락은 동시성 문제를 해결할 수 있지만 로직을 진행하는 동안 다른 쓰레드에서는 로직을 실행하지 못하고 대기 상태에 빠진다. 이로 인해 동시에 접근하는 트랜잭션이 많아지면 많아질수록 API 콜의 대기 시간은 늘어나게 되어 비효율적이기 때문에 보류하였다.

### foreign key 제거

데드락을 유발시키는 공유락을 획득하지 못하도록 외래키 제약조건 제거하였다. 이와 함께 기존에는 cascade 로 삭제했기때문에 약속잡기 삭제시 선택 가능 시간도 제거하는 로직을 추가하였다.

2. 낙관락

```
@Getter
@Entity
@NoArgsConstructor
public class Appointment extends BaseRootEntity<Appointment> {

    @Version
    private Integer version;
}
```

```
@Query("select a from Appointment a where a.menu.code.code = :code")
@Lock(LockModeType.OPTIMISTIC)
Optional<Appointment> findByCode(@Param("code") String code);
```

버전 필드를 추가하고 Lock Mode 로 OPTIMISTIC 을 추가하였다.

![image](https://user-images.githubusercontent.com/42317507/230037604-7d5ba384-4e11-45b2-87b0-9c027ba0ccc1.png)

낙관적 락은 정합성 문제를 해결할 수 있지만, 데이터 유실이 발생한다. 

![image](https://user-images.githubusercontent.com/42317507/230042102-9b06f743-759a-4456-8d8d-3a51a76e324a.png)

데이터 유실을 해결하기 위해서는 비즈니스 로직에서 rollback 이 발생했는지 확인하고 다시 동일한 과정을 수행하는 while 반복문이 필요하다. 그래서 비즈니스 로직에 데이터 유실 방지 로직이 필요해서 비즈니스 로직을 희생해야 하기때문에 낙관적 락도 보류하였다.

3. 비즈니스 로직

```
@Modifying(clearAutomatically =true, flushAutomatically =true)
@Query("update Appointment a "
        + "set a.availableTimes.selectedCount = a.availableTimes.selectedCount + 1 "
        + "where a.menu.code.code = :appointmentCode")
void updateSelectedCount(@Param("appointmentCode") String appointmentCode);
```

![image](https://user-images.githubusercontent.com/42317507/230038183-dc9264d2-83e8-486c-897a-caa25cb863f7.png)

 수정하는 쿼리는 수정하는 시점의 값에서 +1 하는 로직이기때문에 정합성을 맞출 수 있다. 그리고 이 경우 다른 로직으로 인한 공유락을 획득하지 않기에 데드락 문제도 피할 수 있고, 다른 예외 이외에는 롤백이 되지 않기에 데이터 유실 문제도 해결할 수 있다.
