### PR TITLE
테스트를 위한 embedded 레디스 서버를 실행한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -74,7 +74,7 @@ dependencies {
 
     // redis
     implementation 'org.redisson:redisson-spring-boot-starter:3.18.0'
-    implementation 'it.ozimov:embedded-redis:0.7.3'
+    testImplementation 'it.ozimov:embedded-redis:0.7.3'
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -74,6 +74,7 @@ dependencies {
 
     // redis
     implementation 'org.redisson:redisson-spring-boot-starter:3.18.0'
+    implementation 'it.ozimov:embedded-redis:0.7.3'
 }
 
 tasks.named('test') {

--- a/backend/src/test/java/com/morak/back/AcceptanceTest.java
+++ b/backend/src/test/java/com/morak/back/AcceptanceTest.java
@@ -2,12 +2,14 @@ package com.morak.back;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.jdbc.Sql;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql(scripts = {"classpath:schema.sql", "classpath:data.sql"})
+@ExtendWith(EmbeddedRedisCallback.class)
 public class AcceptanceTest {
 
     @LocalServerPort

--- a/backend/src/test/java/com/morak/back/EmbeddedRedisCallback.java
+++ b/backend/src/test/java/com/morak/back/EmbeddedRedisCallback.java
@@ -7,12 +7,13 @@ import redis.embedded.RedisServer;
 
 public class EmbeddedRedisCallback implements BeforeAllCallback, AfterAllCallback {
 
-    private static final int REDIS_PORT = 6379;
+    private static final int EMBEDDED_REDIS_PORT = 16379;
+
     private RedisServer redisServer;
 
     @Override
     public void beforeAll(ExtensionContext context) {
-        redisServer = new RedisServer(REDIS_PORT);
+        redisServer = new RedisServer(EMBEDDED_REDIS_PORT);
         redisServer.start();
     }
 

--- a/backend/src/test/java/com/morak/back/EmbeddedRedisCallback.java
+++ b/backend/src/test/java/com/morak/back/EmbeddedRedisCallback.java
@@ -1,0 +1,25 @@
+package com.morak.back;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import redis.embedded.RedisServer;
+
+public class EmbeddedRedisCallback implements BeforeAllCallback, AfterAllCallback {
+
+    private static final int REDIS_PORT = 6379;
+    private RedisServer redisServer;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        redisServer = new RedisServer(REDIS_PORT);
+        redisServer.start();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+}

--- a/backend/src/test/java/com/morak/back/MorakBackApplicationTests.java
+++ b/backend/src/test/java/com/morak/back/MorakBackApplicationTests.java
@@ -1,9 +1,11 @@
 package com.morak.back;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@ExtendWith(EmbeddedRedisCallback.class)
 class MorakBackApplicationTests {
 
     @Test

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -63,6 +63,8 @@ spring:
   sql:
     init:
       mode: always
+  redis:
+    port: 16379
 
 ---
 


### PR DESCRIPTION
## 상세 내용
Close #620 

### 문제점

- 레디스 서버가 테스트 환경 시에 떠있지 않으면 커넥션 에러가 발생하였습니다.
- 모든 테스트 환경에서 테스트가 통과할 수 있도록 레디스 서버에 독립적인 테스트 환경을 만들어야 합니다.

### 고려해본 사항

- 스프링 도커로 레디스 서버 띄우기
  - 이 방식은 스프링 도커로 레디스 서버를 띄우고 해당 서버로 커넥션을 연결하는 방식입니다.
  - 스프링 도커로 레디스 서버를 실행시키는 시간이 오래 걸리는 문제점과 스프링 도커가 테스트하는 환경의 운영체제에 다소 의존적인 경향이 있어 보류하였습니다.

- 레디스 관련 클래스 모킹하기
  - 현재 사용하는 RedissonClient 를 모킹하면 해당 구현체가 연결을 시도하던 로직이 실행되지 않아 연결을 하지 않고 테스트를 통과할 수 있습니다.
  - 하지만 통합 테스트 시에 레디스 분산락 관련 로직이 수행되어 단순한 모킹으로는 해결할 수 없습니다.
  - 그래서 목 객체를 만들고자 하였지만 구현해야 하는 메서드가 너무 많아 보류하였습니다.

-> 이에 따라 임베디드 레디스 서버 의존성을 추가하여 사용하였습니다. 임베디드 레디스 서버를 활용하는 방법은 두 가지가 있습니다.

- 가장 널리 알려진 빈 등록 시에 `@ PostConstruct` 와 `@PreDestroy` 를 활용하여 임베디드 레디스 서버를 구축하는 방식입니다([관련 jojoldu님 포스팅](https://jojoldu.tistory.com/297)).
  - 해당 방식은 단일 스프링부트테스트에서는 활용도가 높지만 스프링부트테스트가 여러 개일 때에는 포스팅에 나온 것과 같이 포트 충돌이 발생하여 포트를 확인하고 비어있는 포트로 띄워줘야 하는 불편함이 있습니다(아마 레디스 서버를 내리는 중에 새로운 레디스 서버를 띄우려고 시도해서 포트 충돌이 일어나는 것 같습니다).
  - 또한 포트를 확인하고 비어있는 포트를 확인하는 과정에서 명령어를 수행하기때문에 위험할 수도 있다고 판단하였습니다.

- 결론적으로 Junit5 의 Callback 을 활용하여 해결하였습니다.
  - 모든 테스트를 실행할 시에도 한번만 임베디드 레디스 서버를 띄우기 때문에 포트충돌할 가능성이 없습니다.
  - 또한 코드가 직관적이기때문에 유지/보수에도 효율적이라고 판단합니다.
  - 생각해본 문제점은 두 가지가 있는데, 하나는 외부 의존성을 사용해서 신뢰도가 다소 떨어질 수 있다는 부분이 있고, 두번째로는 스프링부트테스트를 추가할 때마다 익스텐션을 추가해야 한다는 점입니다.